### PR TITLE
feat: animation polish — strong easing, transition-all removal, press feedback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1716,7 +1716,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@emailjs/browser/-/browser-4.4.1.tgz",
       "integrity": "sha512-DGSlP9sPvyFba3to2A50kDtZ+pXVp/0rhmqs2LmbMS3I5J8FSOgLwzY2Xb4qfKlOVHh29EAutLYwe5yuEZmEFg==",
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -8107,7 +8106,6 @@
       "version": "12.38.0",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
       "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
-      "license": "MIT",
       "dependencies": {
         "motion-dom": "^12.38.0",
         "motion-utils": "^12.36.0",

--- a/src/app/[locale]/(admin)/admin/login/page.tsx
+++ b/src/app/[locale]/(admin)/admin/login/page.tsx
@@ -94,7 +94,7 @@ export default function AdminLoginPage() {
           borderRadius: 16,
           border: "1px solid #2a2d3a",
           overflow: "hidden",
-          animation: "fadeUp 0.4s ease both",
+          animation: "fadeUp 0.35s cubic-bezier(0.23,1,0.32,1) both",
         }}
       >
         {/* Amber top accent bar */}
@@ -245,12 +245,6 @@ export default function AdminLoginPage() {
         </div>
       </div>
 
-      <style>{`
-        @keyframes fadeUp {
-          from { opacity: 0; transform: translateY(20px); }
-          to { opacity: 1; transform: translateY(0); }
-        }
-      `}</style>
     </div>
   );
 }

--- a/src/app/[locale]/(admin)/admin/page.tsx
+++ b/src/app/[locale]/(admin)/admin/page.tsx
@@ -136,7 +136,7 @@ export default async function AdminDashboardPage() {
               borderLeft: "3px solid #f59e0b",
               borderRadius: 12,
               padding: "20px 24px",
-              animation: `fadeUp 0.4s ease ${stat.delay} both`,
+              animation: `fadeUp 0.35s cubic-bezier(0.23,1,0.32,1) ${stat.delay} both`,
             }}
           >
             <div style={{ fontSize: 12, color: "#64748b", textTransform: "uppercase", letterSpacing: "0.1em", marginBottom: 8 }}>
@@ -221,12 +221,6 @@ export default async function AdminDashboardPage() {
         <LanguageManager />
       </section>
 
-      <style>{`
-        @keyframes fadeUp {
-          from { opacity: 0; transform: translateY(16px); }
-          to { opacity: 1; transform: translateY(0); }
-        }
-      `}</style>
     </div>
   );
 }

--- a/src/app/[locale]/(main)/projects/[id]/page.tsx
+++ b/src/app/[locale]/(main)/projects/[id]/page.tsx
@@ -508,7 +508,7 @@ export default function ProjectDetailPage() {
             </div>
             <div className="w-full bg-muted rounded-full h-2 overflow-hidden">
               <div
-                className="bg-primary h-2 rounded-full transition-all duration-700 ease-out"
+                className="bg-primary h-2 rounded-full transition-[width] duration-500 ease-out"
                 style={{ width: `${simulatedProgress}%` }}
               />
             </div>

--- a/src/app/[locale]/(main)/projects/page.tsx
+++ b/src/app/[locale]/(main)/projects/page.tsx
@@ -124,7 +124,7 @@ export default function ProjectsPage() {
             const Icon = config.icon;
             return (
               <Link key={chat.chatId} href={`/projects/${chat.chatId}`}>
-                <Card className="p-4 border border-border/60 hover:border-primary/30 hover:shadow-sm transition-all cursor-pointer group">
+                <Card className="p-4 border border-border/60 hover:border-primary/30 hover:shadow-sm transition-[border-color,box-shadow] cursor-pointer group">
                   <div className="flex items-center gap-4">
                     <div className={`p-2.5 rounded-lg shrink-0 ${config.bg}`}>
                       <Icon className={`h-5 w-5 ${config.color}`} />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -255,7 +255,7 @@ html {
 }
 
 .animate-fade-in-up {
-  animation: fade-in-up 0.6s ease-out forwards;
+  animation: fade-in-up 0.4s var(--ease-out-strong) forwards;
   opacity: 0;
 }
 
@@ -340,13 +340,15 @@ html {
 }
 
 .blog-banner-stat {
-  transition: all 0.3s ease-in-out;
+  transition: transform 0.3s var(--ease-out-strong);
   position: relative;
   z-index: 1;
 }
 
-.blog-banner-stat:hover {
-  transform: translateY(-4px);
+@media (hover: hover) and (pointer: fine) {
+  .blog-banner-stat:hover {
+    transform: translateY(-4px);
+  }
 }
 
 .blog-banner-stat:hover .group-hover\:scale-110 {
@@ -355,28 +357,28 @@ html {
 
 /* Aurora Background — blob drift animations */
 @keyframes aurora-drift-1 {
-  0%   { transform: translate(0%,   0%)   scale(1);    border-radius: 60% 40% 70% 30% / 50% 60% 40% 70%; }
-  25%  { transform: translate(6%,   8%)   scale(1.08); border-radius: 40% 60% 30% 70% / 70% 30% 60% 40%; }
-  50%  { transform: translate(12%,  4%)   scale(0.95); border-radius: 70% 30% 50% 50% / 30% 70% 50% 50%; }
-  75%  { transform: translate(4%,  -6%)   scale(1.05); border-radius: 50% 50% 40% 60% / 60% 40% 70% 30%; }
-  100% { transform: translate(0%,   0%)   scale(1);    border-radius: 60% 40% 70% 30% / 50% 60% 40% 70%; }
+  0%   { transform: translate(0%,   0%)   scale(1);    }
+  25%  { transform: translate(6%,   8%)   scale(1.08); }
+  50%  { transform: translate(12%,  4%)   scale(0.95); }
+  75%  { transform: translate(4%,  -6%)   scale(1.05); }
+  100% { transform: translate(0%,   0%)   scale(1);    }
 }
 @keyframes aurora-drift-2 {
-  0%   { transform: translate(0%,   0%)  scale(1);    border-radius: 40% 60% 60% 40% / 70% 30% 70% 30%; }
-  33%  { transform: translate(-8%, 10%)  scale(1.1);  border-radius: 60% 40% 40% 60% / 30% 70% 30% 70%; }
-  66%  { transform: translate(-4%, -8%)  scale(0.92); border-radius: 50% 50% 70% 30% / 40% 60% 50% 50%; }
-  100% { transform: translate(0%,   0%)  scale(1);    border-radius: 40% 60% 60% 40% / 70% 30% 70% 30%; }
+  0%   { transform: translate(0%,   0%)  scale(1);    }
+  33%  { transform: translate(-8%, 10%)  scale(1.1);  }
+  66%  { transform: translate(-4%, -8%)  scale(0.92); }
+  100% { transform: translate(0%,   0%)  scale(1);    }
 }
 @keyframes aurora-drift-3 {
-  0%   { transform: translate(0%,   0%)  scale(1);    border-radius: 70% 30% 40% 60% / 40% 70% 30% 60%; }
-  40%  { transform: translate(5%, -10%)  scale(1.12); border-radius: 30% 70% 60% 40% / 60% 40% 70% 30%; }
-  80%  { transform: translate(-5%,  6%)  scale(0.97); border-radius: 60% 40% 30% 70% / 30% 60% 40% 70%; }
-  100% { transform: translate(0%,   0%)  scale(1);    border-radius: 70% 30% 40% 60% / 40% 70% 30% 60%; }
+  0%   { transform: translate(0%,   0%)  scale(1);    }
+  40%  { transform: translate(5%, -10%)  scale(1.12); }
+  80%  { transform: translate(-5%,  6%)  scale(0.97); }
+  100% { transform: translate(0%,   0%)  scale(1);    }
 }
 @keyframes aurora-drift-4 {
-  0%   { transform: translate(0%,   0%)  scale(1);    border-radius: 50% 50% 60% 40% / 60% 40% 50% 50%; }
-  50%  { transform: translate(-6%, -6%)  scale(1.15); border-radius: 40% 60% 50% 50% / 50% 50% 40% 60%; }
-  100% { transform: translate(0%,   0%)  scale(1);    border-radius: 50% 50% 60% 40% / 60% 40% 50% 50%; }
+  0%   { transform: translate(0%,   0%)  scale(1);    }
+  50%  { transform: translate(-6%, -6%)  scale(1.15); }
+  100% { transform: translate(0%,   0%)  scale(1);    }
 }
 
 /* Aurora — light mode: visible; dark mode: full vibrance */
@@ -541,6 +543,8 @@ body {
   --suliko-default-hover-color: #11289c;
   --suliko-main-content-bg-color: #e6e6e7;
   --radius: 0.625rem;
+  --ease-out-strong: cubic-bezier(0.23, 1, 0.32, 1);
+  --ease-in-out-strong: cubic-bezier(0.77, 0, 0.175, 1);
 
   --background: #ffffff;
   --foreground: #0a0a0a;
@@ -751,7 +755,7 @@ html.dark .sidebar-main {
 }
 
 .animate-slideInFromTop {
-  animation: slideInFromTop 0.3s ease-out forwards;
+  animation: slideInFromTop 0.2s var(--ease-out-strong) forwards;
 }
 
 /* Star Field Animations */
@@ -904,15 +908,15 @@ html.dark .sidebar-main {
 }
 
 .animate-fadeInUp {
-  animation: fadeInUp 0.6s ease-out forwards;
+  animation: fadeInUp 0.4s var(--ease-out-strong) forwards;
 }
 
 .animate-fadeInLeft {
-  animation: fadeInLeft 0.6s ease-out forwards;
+  animation: fadeInLeft 0.4s var(--ease-out-strong) forwards;
 }
 
 .animate-fadeInRight {
-  animation: fadeInRight 0.6s ease-out forwards;
+  animation: fadeInRight 0.4s var(--ease-out-strong) forwards;
 }
 
 .animate-float {
@@ -922,8 +926,8 @@ html.dark .sidebar-main {
 /* Intersection Observer animations */
 .fade-in {
   opacity: 0;
-  transform: translateY(30px);
-  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+  transform: translateY(20px);
+  transition: opacity 0.4s var(--ease-out-strong), transform 0.4s var(--ease-out-strong);
 }
 
 .fade-in.visible {
@@ -1133,6 +1137,16 @@ html.dark .sidebar-main {
 
 .animate-accordion-up {
   animation: accordion-up 0.2s ease-out;
+}
+
+/* Shared fadeUp utility — used by admin login, dashboard, etc. */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(16px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.animate-fadeUp {
+  animation: fadeUp 0.35s var(--ease-out-strong) both;
 }
 
 /* Move Crisp chat widget to right-middle on mobile — handled via JS CRISP_READY_TRIGGER */

--- a/src/components/blog/BlogCard.tsx
+++ b/src/components/blog/BlogCard.tsx
@@ -15,7 +15,7 @@ export default function BlogCard({ post }: BlogCardProps) {
   const t = useTranslations("Blog.card");
 
   return (
-    <article className="group flex flex-col bg-card/80 backdrop-blur-sm rounded-xl border border-border/50 overflow-hidden hover:shadow-lg transition-all duration-300 hover:border-primary/20 hover:bg-card hover:-translate-y-0.5">
+    <article className="group flex flex-col bg-card/80 backdrop-blur-sm rounded-xl border border-border/50 overflow-hidden hover:shadow-lg transition-[transform,box-shadow,border-color,background-color] duration-300 hover:border-primary/20 hover:bg-card [@media(hover:hover)]:hover:-translate-y-0.5">
       <Link href={`/blog/${post.slug}`} className="flex flex-col flex-1">
         {/* Image / fallback */}
         <div className="relative h-52 w-full overflow-hidden bg-gradient-to-br from-primary/10 to-primary/5 flex-shrink-0">
@@ -70,7 +70,7 @@ export default function BlogCard({ post }: BlogCardProps) {
               )}
             </div>
 
-            <span className="flex items-center gap-1 text-xs text-primary font-medium group-hover:gap-2 transition-all duration-200">
+            <span className="flex items-center gap-1 text-xs text-primary font-medium group-hover:gap-2 transition-[gap] duration-200">
               {t("readMore")}
               <ArrowRight className="h-3 w-3" />
             </span>

--- a/src/features/chatHistory/components/ChatSuggestionsPanel.tsx
+++ b/src/features/chatHistory/components/ChatSuggestionsPanel.tsx
@@ -164,7 +164,7 @@ const ChatSuggestionsPanel: React.FC<ChatSuggestionsPanelProps> = ({
               onMouseLeave={() => {
                 setHoveredSuggestionOriginalText(null);
               }}
-              className="bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-3 flex flex-col w-full sm:min-w-[260px] sm:max-w-[360px] gap-2 shadow-sm hover:shadow-md hover:border-suliko-default-color/30 transition-all duration-200"
+              className="bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-3 flex flex-col w-full sm:min-w-[260px] sm:max-w-[360px] gap-2 shadow-sm hover:shadow-md hover:border-suliko-default-color/30 transition-[box-shadow,border-color] duration-200"
             >
               <div className="flex items-center justify-between gap-2">
                 <div className="font-semibold text-foreground" title={s.title}>

--- a/src/features/pricing/components/PricingCard.tsx
+++ b/src/features/pricing/components/PricingCard.tsx
@@ -70,7 +70,7 @@ export function PricingCard({ type, onSelect }: PricingCardProps) {
   };
 
   return (
-    <div className="bg-card rounded-2xl shadow-sm p-8 border border-border/60 flex flex-col h-full hover:border-primary/30 hover:shadow-md transition-all duration-200">
+    <div className="bg-card rounded-2xl shadow-sm p-8 border border-border/60 flex flex-col h-full hover:border-primary/30 hover:shadow-md transition-[border-color,box-shadow] duration-200">
       {renderCardContent()}
       <div className="mt-auto pt-8">
         <button

--- a/src/features/ui/components/loading/TranslationLoadingOverlay.tsx
+++ b/src/features/ui/components/loading/TranslationLoadingOverlay.tsx
@@ -131,7 +131,7 @@ const TranslationLoadingOverlay: React.FC<TranslationLoadingOverlayProps> = ({
           </div>
           <div className="w-full bg-muted rounded-full h-2">
             <div
-              className="bg-suliko-default-color h-2 rounded-full transition-all duration-300 ease-out"
+              className="bg-suliko-default-color h-2 rounded-full transition-[width] duration-300 ease-out"
               style={{ width: `${Math.min(100, Math.max(0, progress))}%` }}
             />
           </div>

--- a/src/features/ui/components/ui/accordion.tsx
+++ b/src/features/ui/components/ui/accordion.tsx
@@ -35,7 +35,7 @@ function AccordionTrigger({
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
-          "flex flex-1 items-center justify-between py-4 text-left text-sm font-medium text-foreground transition-all hover:text-primary [&[data-state=open]>svg]:rotate-180",
+          "flex flex-1 items-center justify-between py-4 text-left text-sm font-medium text-foreground transition-colors hover:text-primary [&[data-state=open]>svg]:rotate-180",
           className
         )}
         {...props}

--- a/src/features/ui/components/ui/button.tsx
+++ b/src/features/ui/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/shared/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[transform,box-shadow,background-color,color,opacity] duration-150 active:scale-[0.97] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer",
   {
     variants: {
       variant: {

--- a/src/shared/components/SulikoForm.tsx
+++ b/src/shared/components/SulikoForm.tsx
@@ -585,7 +585,7 @@ const SulikoForm: React.FC = () => {
                         <button
                           type="button"
                           onClick={() => setVerificationMethod("phone")}
-                          className="group relative flex flex-col items-center justify-center p-6 border-2 border-border rounded-xl hover:border-suliko-default-color transition-all duration-200 hover:shadow-md bg-card cursor-pointer"
+                          className="group relative flex flex-col items-center justify-center p-6 border-2 border-border rounded-xl hover:border-suliko-default-color transition-[border-color,box-shadow] duration-200 hover:shadow-md bg-card cursor-pointer"
                         >
                           <div className="text-4xl mb-3">📱</div>
                           <div className="text-lg font-semibold text-foreground mb-1">
@@ -598,7 +598,7 @@ const SulikoForm: React.FC = () => {
                         <button
                           type="button"
                           onClick={() => setVerificationMethod("email")}
-                          className="group relative flex flex-col items-center justify-center p-6 border-2 border-border rounded-xl hover:border-suliko-default-color transition-all duration-200 hover:shadow-md bg-card cursor-pointer"
+                          className="group relative flex flex-col items-center justify-center p-6 border-2 border-border rounded-xl hover:border-suliko-default-color transition-[border-color,box-shadow] duration-200 hover:shadow-md bg-card cursor-pointer"
                         >
                           <div className="text-4xl mb-3">📧</div>
                           <div className="text-lg font-semibold text-foreground mb-1">


### PR DESCRIPTION
## Summary
- Replace `transition-all` with specific property lists across 8 components to avoid unnecessary layout-triggering repaints
- Add `active:scale-[0.97]` press feedback to the base `Button` component (applies site-wide)
- Add `--ease-out-strong` and `--ease-in-out-strong` CSS custom properties (`cubic-bezier(0.23,1,0.32,1)` / `cubic-bezier(0.77,0,0.175,1)`) and apply them to all fade/slide animations
- Strip `border-radius` from aurora blob keyframes so they only animate `transform` (GPU-only)
- Tighten durations: 0.6s → 0.4s for fade-ins, 700ms → 500ms progress bars
- Guard hover translations with `@media (hover: hover)` on BlogCard and `.blog-banner-stat`
- Consolidate duplicate `@keyframes fadeUp` from two admin pages into `globals.css`

## Test plan
- [ ] Click any button — should feel slightly springy (scale feedback)
- [ ] Hover over a blog card on a desktop browser — card should lift; no lift on mobile/touch
- [ ] Open a project with a progress bar — width transition should feel snappy
- [ ] Open/close accordion — only color transitions (no layout thrash)
- [ ] Check admin login page entrance animation still plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)