### PR TITLE
fix: refresh user balance on payment success page

### DIFF
--- a/src/app/[locale]/payment/success/page.tsx
+++ b/src/app/[locale]/payment/success/page.tsx
@@ -6,21 +6,17 @@ import { Card, CardContent } from "@/features/ui";
 import { Button } from "@/features/ui";
 import LandingHeader from "@/shared/components/LandingHeader";
 import LandingFooter from "@/shared/components/LandingFooter";
+import { useUserStore } from "@/features/auth/store/userStore";
 
 export default function PaymentSuccessPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const fetchUserProfileWithRetry = useUserStore((s) => s.fetchUserProfileWithRetry);
 
   useEffect(() => {
-    // You can extract payment information from URL parameters if needed
-    const orderId = searchParams.get('orderId');
-    const transactionId = searchParams.get('transactionId');
-    
-    if (orderId || transactionId) {
-      console.log('Payment success - Order ID:', orderId, 'Transaction ID:', transactionId);
-      // TODO: Fetch payment details and update user balance
-    }
-  }, [searchParams]);
+    // Refresh balance after payment — webhook may take a few seconds to process
+    fetchUserProfileWithRetry(5, 2000);
+  }, [fetchUserProfileWithRetry]);
 
   return (
     <div className="min-h-screen relative">


### PR DESCRIPTION
## Summary

- The `/payment/success` page had a hardcoded "Your balance has been updated" message but never actually fetched the updated user profile
- Balance only updated if the user navigated away and triggered a profile fetch elsewhere
- Now calls `fetchUserProfileWithRetry(5, 2000)` on mount — retries up to 5 times with 2 s between attempts, giving the Flitt webhook time to process before the UI reflects the new balance

## Test plan

- [ ] Complete a Flitt test payment and land on the success page
- [ ] Verify the balance displayed in the sidebar/profile updates automatically without manual navigation
- [ ] Verify no console errors related to the profile fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)