### PR TITLE
fix: remove unused searchParams causing ESLint build failure

### DIFF
--- a/src/app/[locale]/payment/success/page.tsx
+++ b/src/app/[locale]/payment/success/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { Card, CardContent } from "@/features/ui";
 import { Button } from "@/features/ui";
 import LandingHeader from "@/shared/components/LandingHeader";
@@ -10,7 +10,6 @@ import { useUserStore } from "@/features/auth/store/userStore";
 
 export default function PaymentSuccessPage() {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const fetchUserProfileWithRetry = useUserStore((s) => s.fetchUserProfileWithRetry);
 
   useEffect(() => {


### PR DESCRIPTION
Leftover `searchParams` import and variable from the previous refactor triggered an ESLint `no-unused-vars` error that failed the Vercel build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)