### PR TITLE
feat: make Flitt the default payment provider

### DIFF
--- a/src/features/pricing/components/PayAsYouGoModal.tsx
+++ b/src/features/pricing/components/PayAsYouGoModal.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/features/ui/components/ui/button';
 import { Input } from '@/features/ui/components/ui/input';
 import { Label } from '@/features/ui/components/ui/label';
 import { CreditCard, AlertCircle } from "lucide-react";
-import { createPayment } from "../services/paymentService";
+import { createFlittPayment } from "../services/paymentService";
 import { getCurrencySymbol, isSulikoIo } from "@/shared/utils/domainUtils";
 import { ContactPaymentModal } from "./ContactPaymentModal";
 
@@ -90,9 +90,8 @@ export function PayAsYouGoModal({ isOpen, onClose }: PayAsYouGoModalProps) {
 
     try {
       const numericAmount = parseFloat(amount);
-      // Currency and country will be determined automatically based on domain
-      const response = await createPayment(numericAmount);
-      window.open(response.redirectUrl, "_blank");
+      const response = await createFlittPayment(numericAmount);
+      window.open(response.checkoutUrl, "_blank");
       onClose();
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : t('payAsYouGoModal.errors.purchaseFailed');

--- a/src/features/pricing/components/PricingGrid.tsx
+++ b/src/features/pricing/components/PricingGrid.tsx
@@ -30,7 +30,7 @@ export function PricingGrid() {
       return;
     }
 
-    const choice = localStorage.getItem("paymentChoice") || "paysera";
+    const choice = localStorage.getItem("paymentChoice") || "flitt";
 
     // For suliko.io, show contact modal instead of making payment API call
     if (isSulikoIo()) {


### PR DESCRIPTION
## Summary

- `PricingGrid`: changed `localStorage` fallback from `"paysera"` to `"flitt"` — users without an explicit stored choice now go through Flitt
- `PayAsYouGoModal`: was hardcoded to Paysera (`createPayment`) regardless of the stored choice; switched to `createFlittPayment`

🤖 Generated with [Claude Code](https://claude.com/claude-code)