### PR TITLE
fix: improve add-card error message visibility

### DIFF
--- a/src/features/pricing/services/savedCardService.ts
+++ b/src/features/pricing/services/savedCardService.ts
@@ -36,7 +36,9 @@ async function withTokenRefresh<T>(fn: (headers: Headers) => Promise<Response>):
 
   if (!response.ok) {
     const err = await response.json().catch(() => ({}));
-    throw new Error(err.message || "Request failed");
+    const msg = err.error || err.message || "Request failed";
+    const detail = err.detail ? ` (${err.detail})` : err.flittStatus ? ` [Flitt: ${err.flittStatus}]` : "";
+    throw new Error(msg + detail);
   }
 
   return response.json() as Promise<T>;


### PR DESCRIPTION
## Summary
- Read `err.error` field from backend response (was checking `err.message` which doesn't exist in our error shape)
- Append inner exception detail and Flitt status code to error toast so root cause is visible to the user

## Test plan
- Trigger an add-card failure and confirm the error toast shows the real reason instead of "Request failed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)