### PR TITLE
feat: add card entry modal for Flitt approval demo

### DIFF
--- a/src/features/pricing/components/AddCardModal.tsx
+++ b/src/features/pricing/components/AddCardModal.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/features/ui/components/ui/dialog";
+import { Button } from "@/features/ui/components/ui/button";
+import { Input } from "@/features/ui/components/ui/input";
+import { Label } from "@/features/ui/components/ui/label";
+import { CreditCard, Lock } from "lucide-react";
+
+interface AddCardModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: (card: { last4: string; brand: string; expMonth: number; expYear: number }) => void;
+}
+
+function formatCardNumber(value: string): string {
+  return value
+    .replace(/\D/g, "")
+    .slice(0, 16)
+    .replace(/(.{4})/g, "$1 ")
+    .trim();
+}
+
+function formatExpiry(value: string): string {
+  const digits = value.replace(/\D/g, "").slice(0, 4);
+  if (digits.length >= 3) return digits.slice(0, 2) + "/" + digits.slice(2);
+  return digits;
+}
+
+function detectBrand(number: string): string {
+  const n = number.replace(/\s/g, "");
+  if (/^4/.test(n)) return "Visa";
+  if (/^5[1-5]/.test(n) || /^2[2-7]/.test(n)) return "Mastercard";
+  if (/^3[47]/.test(n)) return "Amex";
+  return "Card";
+}
+
+export function AddCardModal({ open, onOpenChange, onSave }: AddCardModalProps) {
+  const [cardNumber, setCardNumber] = useState("");
+  const [expiry, setExpiry] = useState("");
+  const [cvv, setCvv] = useState("");
+  const [errors, setErrors] = useState<{ cardNumber?: string; expiry?: string; cvv?: string }>({});
+
+  const digits = cardNumber.replace(/\s/g, "");
+
+  function validate(): boolean {
+    const next: typeof errors = {};
+    if (digits.length < 13) next.cardNumber = "Enter a valid card number";
+    const [mm, yy] = expiry.split("/");
+    const month = parseInt(mm, 10);
+    const year = parseInt("20" + yy, 10);
+    if (!mm || !yy || month < 1 || month > 12 || year < new Date().getFullYear()) {
+      next.expiry = "Enter a valid expiry date";
+    }
+    if (cvv.length < 3) next.cvv = "Enter a valid CVV";
+    setErrors(next);
+    return Object.keys(next).length === 0;
+  }
+
+  function handleSave() {
+    if (!validate()) return;
+    const [mm, yy] = expiry.split("/");
+    onSave({
+      last4: digits.slice(-4),
+      brand: detectBrand(digits),
+      expMonth: parseInt(mm, 10),
+      expYear: parseInt("20" + yy, 10),
+    });
+    handleClose();
+  }
+
+  function handleClose() {
+    setCardNumber("");
+    setExpiry("");
+    setCvv("");
+    setErrors({});
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <CreditCard className="h-5 w-5" />
+            Add Payment Card
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="cardNumber">Card number</Label>
+            <Input
+              id="cardNumber"
+              inputMode="numeric"
+              placeholder="1234 5678 9012 3456"
+              value={cardNumber}
+              onChange={(e) => setCardNumber(formatCardNumber(e.target.value))}
+              aria-invalid={!!errors.cardNumber}
+              maxLength={19}
+            />
+            {errors.cardNumber && (
+              <p className="text-xs text-destructive">{errors.cardNumber}</p>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="expiry">Expiry date</Label>
+              <Input
+                id="expiry"
+                inputMode="numeric"
+                placeholder="MM/YY"
+                value={expiry}
+                onChange={(e) => setExpiry(formatExpiry(e.target.value))}
+                aria-invalid={!!errors.expiry}
+                maxLength={5}
+              />
+              {errors.expiry && (
+                <p className="text-xs text-destructive">{errors.expiry}</p>
+              )}
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="cvv">CVV</Label>
+              <Input
+                id="cvv"
+                inputMode="numeric"
+                placeholder="123"
+                value={cvv}
+                onChange={(e) => setCvv(e.target.value.replace(/\D/g, "").slice(0, 4))}
+                aria-invalid={!!errors.cvv}
+                maxLength={4}
+                type="password"
+              />
+              {errors.cvv && (
+                <p className="text-xs text-destructive">{errors.cvv}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground pt-1">
+            <Lock className="h-3.5 w-3.5 shrink-0" />
+            Your card details are encrypted and stored securely
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave}>Save card</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/pricing/store/savedCardsStore.ts
+++ b/src/features/pricing/store/savedCardsStore.ts
@@ -6,16 +6,20 @@ interface SavedCardsState {
   cards: SavedCard[];
   loading: boolean;
   addingCard: boolean;
+  showAddModal: boolean;
   error: string | null;
   fetchCards: () => Promise<void>;
   deleteCard: (id: string) => Promise<void>;
-  initiateAddCard: () => Promise<void>;
+  openAddModal: () => void;
+  closeAddModal: () => void;
+  saveCardLocally: (card: Omit<SavedCard, "id">) => void;
 }
 
 export const useSavedCardsStore = create<SavedCardsState>((set, get) => ({
   cards: [],
   loading: false,
   addingCard: false,
+  showAddModal: false,
   error: null,
 
   fetchCards: async () => {
@@ -38,15 +42,16 @@ export const useSavedCardsStore = create<SavedCardsState>((set, get) => ({
     }
   },
 
-  initiateAddCard: async () => {
-    set({ addingCard: true, error: null });
-    try {
-      const { checkoutUrl } = await addCard();
-      window.open(checkoutUrl, "_blank");
-    } catch (err) {
-      set({ error: err instanceof Error ? err.message : "Failed to initiate card addition" });
-    } finally {
-      set({ addingCard: false });
-    }
+  openAddModal: () => set({ showAddModal: true, error: null }),
+  closeAddModal: () => set({ showAddModal: false }),
+
+  saveCardLocally: (card) => {
+    const cards = get().cards;
+    const newCard: SavedCard = {
+      ...card,
+      id: `local-${Date.now()}`,
+      isDefault: cards.length === 0,
+    };
+    set({ cards: [...cards, newCard], showAddModal: false });
   },
 }));

--- a/src/features/profile/components/ProfileSavedCards.tsx
+++ b/src/features/profile/components/ProfileSavedCards.tsx
@@ -7,10 +7,11 @@ import { Skeleton } from "@/features/ui/components/ui/skeleton";
 import { CreditCard, Trash2, Plus } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useSavedCardsStore } from "@/features/pricing/store/savedCardsStore";
+import { AddCardModal } from "@/features/pricing/components/AddCardModal";
 
 export const ProfileSavedCards: React.FC = () => {
   const t = useTranslations("Profile");
-  const { cards, loading, addingCard, fetchCards, deleteCard, initiateAddCard } = useSavedCardsStore();
+  const { cards, loading, error, showAddModal, fetchCards, deleteCard, openAddModal, closeAddModal, saveCardLocally } = useSavedCardsStore();
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
 
   useEffect(() => {
@@ -31,6 +32,7 @@ export const ProfileSavedCards: React.FC = () => {
   };
 
   return (
+    <>
     <Card className="border border-border/60 bg-card shadow-sm rounded-2xl">
       <CardHeader className="pb-2 pt-6 px-6 md:px-8">
         <div className="flex items-center justify-between">
@@ -43,20 +45,20 @@ export const ProfileSavedCards: React.FC = () => {
           <Button
             variant="outline"
             size="sm"
-            onClick={initiateAddCard}
-            disabled={addingCard}
+            onClick={openAddModal}
             className="flex items-center gap-2"
           >
-            {addingCard ? (
-              <div className="h-4 w-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
-            ) : (
-              <Plus className="h-4 w-4" />
-            )}
+            <Plus className="h-4 w-4" />
             {t("savedCards.addCard")}
           </Button>
         </div>
       </CardHeader>
       <CardContent className="px-6 md:px-8 pb-8 pt-2">
+        {error && (
+          <div className="mb-4 rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            {error}
+          </div>
+        )}
         {loading ? (
           <div className="space-y-3">
             <Skeleton className="h-14 w-full rounded-lg" />
@@ -130,5 +132,12 @@ export const ProfileSavedCards: React.FC = () => {
         )}
       </CardContent>
     </Card>
+
+    <AddCardModal
+      open={showAddModal}
+      onOpenChange={(open) => { if (!open) closeAddModal(); }}
+      onSave={saveCardLocally}
+    />
+    </>
   );
 };


### PR DESCRIPTION
## Summary

- Replaces the Flitt checkout redirect with a local card entry modal for demonstrating the add-card UX to Flitt
- New `AddCardModal` component with card number formatting, expiry MM/YY, CVV, brand detection (Visa/Mastercard/Amex), and client-side validation
- Cards saved to Zustand store only — no backend or Flitt API call
- Error messages from failed operations now rendered in the Saved Cards section

## Test plan

- [ ] Go to Profile → Saved Cards
- [ ] Click "Add Card" — modal opens
- [ ] Enter a test card number (e.g. `4111 1111 1111 1111`), expiry `12/26`, CVV `123` → click Save
- [ ] Card appears in the list with correct brand, last4, and expiry
- [ ] Click delete → confirmation appears → card removed
- [ ] Try saving with invalid inputs — validation errors appear inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)