### PR TITLE
fix: remove unused addCard import

### DIFF
--- a/src/features/pricing/store/savedCardsStore.ts
+++ b/src/features/pricing/store/savedCardsStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { SavedCard } from "../types/savedCard";
-import { getSavedCards, deleteSavedCard, addCard } from "../services/savedCardService";
+import { getSavedCards, deleteSavedCard } from "../services/savedCardService";
 
 interface SavedCardsState {
   cards: SavedCard[];


### PR DESCRIPTION
## Summary

- Removes the unused `addCard` import in `savedCardsStore.ts` that caused the Vercel ESLint build failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)