### PR TITLE
feat: stack hero CTAs vertically to prevent text overflow

### DIFF
--- a/src/shared/components/HeroSection.tsx
+++ b/src/shared/components/HeroSection.tsx
@@ -94,7 +94,7 @@ export default function HeroSection() {
             </p>
 
             {/* CTAs */}
-            <div className="mb-10 flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:items-center">
+            <div className="mb-10 flex w-full flex-col gap-3 sm:w-auto">
               <Link
                 href="/document"
                 prefetch


### PR DESCRIPTION
## Summary
- Removed `sm:flex-row sm:items-center` from the hero CTA wrapper so buttons always stack vertically
- Fixes secondary button text being cut off by the video

🤖 Generated with [Claude Code](https://claude.com/claude-code)