### PR TITLE
feat: redirect secondary hero CTA to notary page

### DIFF
--- a/src/shared/components/HeroSection.tsx
+++ b/src/shared/components/HeroSection.tsx
@@ -116,7 +116,7 @@ export default function HeroSection() {
                   </span>
                 </LoadingButton>
               </Link>
-              <Link href="#pricing">
+              <Link href="/notary">
                 <Button
                   variant="outline"
                   size="lg"


### PR DESCRIPTION
## Summary
- Changed secondary CTA link from `#pricing` to `/notary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)