### PR TITLE
chore: upgrade Node.js version to 24.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,6 @@
     "typescript": "^5"
   },
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -9,7 +9,7 @@
   },
   "build": {
     "env": {
-      "NODE_VERSION": "20"
+      "NODE_VERSION": "24"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Update `package.json` engines from `20.x` to `24.x`
- Update `vercel.json` `NODE_VERSION` from `20` to `24`

Resolves the Vercel warning: *"Configuration Settings in the current Production deployment differ from your current Project Settings"* — the Vercel dashboard was already set to 24.x but the code still referenced 20.x.

## Test plan
- [ ] Vercel redeploys successfully with Node 24
- [ ] Vercel dashboard → Settings → Node.js Version shows no mismatch warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)