### PR TITLE
fix: render HTML blog content and resolve cross-locale 404s

### DIFF
--- a/src/components/blog/BlogPost.tsx
+++ b/src/components/blog/BlogPost.tsx
@@ -1,6 +1,4 @@
 import Image from 'next/image';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
 import type { BlogPost } from '@/lib/blog';
 import { formatDate } from '@/lib/blog';
 import BlogErrorBoundary from './BlogErrorBoundary';
@@ -64,72 +62,7 @@ export default function BlogPost({ post }: BlogPostProps) {
           }
         >
           {post.content ? (
-            <ReactMarkdown 
-              remarkPlugins={[remarkGfm]}
-              components={{
-                img: ({ src, alt }) => (
-                  <Image
-                    src={typeof src === 'string' ? src : ''}
-                    alt={typeof alt === 'string' ? alt : ''}
-                    width={800}
-                    height={400}
-                    className="rounded-lg"
-                  />
-                ),
-                h1: ({ children, ...props }) => (
-                  <h1 className="text-3xl font-bold mb-4 text-foreground" {...props}>
-                    {children}
-                  </h1>
-                ),
-                h2: ({ children, ...props }) => (
-                  <h2 className="text-2xl font-semibold mb-3 text-foreground" {...props}>
-                    {children}
-                  </h2>
-                ),
-                h3: ({ children, ...props }) => (
-                  <h3 className="text-xl font-semibold mb-2 text-foreground" {...props}>
-                    {children}
-                  </h3>
-                ),
-                p: ({ children, ...props }) => (
-                  <p className="mb-4 text-foreground/90 leading-relaxed" {...props}>
-                    {children}
-                  </p>
-                ),
-                ul: ({ children, ...props }) => (
-                  <ul className="mb-4 ml-6 list-disc text-foreground/90" {...props}>
-                    {children}
-                  </ul>
-                ),
-                ol: ({ children, ...props }) => (
-                  <ol className="mb-4 ml-6 list-decimal text-foreground/90" {...props}>
-                    {children}
-                  </ol>
-                ),
-                li: ({ children, ...props }) => (
-                  <li className="mb-2" {...props}>
-                    {children}
-                  </li>
-                ),
-                blockquote: ({ children, ...props }) => (
-                  <blockquote className="border-l-4 border-primary/20 pl-4 py-2 mb-4 italic text-foreground/80" {...props}>
-                    {children}
-                  </blockquote>
-                ),
-                code: ({ children, ...props }) => (
-                  <code className="bg-muted px-2 py-1 rounded text-sm font-mono" {...props}>
-                    {children}
-                  </code>
-                ),
-                pre: ({ children, ...props }) => (
-                  <pre className="bg-muted p-4 rounded-lg overflow-x-auto mb-4" {...props}>
-                    {children}
-                  </pre>
-                ),
-              }}
-            >
-              {post.content}
-            </ReactMarkdown>
+            <div dangerouslySetInnerHTML={{ __html: post.content }} />
           ) : (
             <div className="text-center py-8">
               <p className="text-muted-foreground">No content available for this post.</p>

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -47,11 +47,11 @@ export async function getAllPosts(locale = 'en'): Promise<BlogPost[]> {
 }
 
 export async function getPostBySlug(slug: string, locale = 'en'): Promise<BlogPost | null> {
+  // Search by slug across all locales so posts with only one locale still resolve
   const { data, error } = await supabase
     .from('blog_post_translations')
     .select('post_id, blog_posts(*, blog_post_translations(*))')
     .eq('slug', slug)
-    .eq('locale', locale)
     .single();
 
   if (error || !data) {
@@ -62,6 +62,7 @@ export async function getPostBySlug(slug: string, locale = 'en'): Promise<BlogPo
   const post = (data as unknown as { blog_posts: BlogPostRow }).blog_posts;
   if (!post || post.status !== 'published') return null;
 
+  // rowToPost falls back to 'en' if requested locale has no translation
   return rowToPost(post, locale);
 }
 


### PR DESCRIPTION
## Summary
- Blog posts with only English translations no longer 404 when accessed from any locale URL
- HTML content from TipTap editor and seeded posts now renders correctly (headings, lists, bold, etc.) instead of showing raw tags

## Changes
- `src/lib/blog.ts`: removed locale filter from slug lookup in `getPostBySlug` — finds post by slug first, then falls back to EN translation if the requested locale has no content
- `src/components/blog/BlogPost.tsx`: replaced `ReactMarkdown` with `dangerouslySetInnerHTML` since all blog content is stored as HTML

## Test plan
- [x] `/en/blog/certified-translation-georgia` renders with proper headings and formatting
- [x] Old migrated posts no longer return 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)