### PR TITLE
feat: 2-column field grid + sticky right panel (Variation C)

### DIFF
--- a/src/features/passport/components/PassportFieldsForm.tsx
+++ b/src/features/passport/components/PassportFieldsForm.tsx
@@ -16,6 +16,12 @@ interface Props {
   extracting?: boolean;
 }
 
+// Keys that contain long values and should span both grid columns
+const WIDE_PATTERNS = ["mrz", "surname", "given_names", "place_of_birth", "authority", "personal_number"];
+function isWideField(key: string) {
+  return WIDE_PATTERNS.some((p) => key.includes(p));
+}
+
 function ConfidenceBadge({ score, empty }: { score?: number; empty?: boolean }) {
   if (empty) {
     return (
@@ -41,16 +47,16 @@ function ConfidenceBadge({ score, empty }: { score?: number; empty?: boolean }) 
 }
 
 function getFieldAccent(empty: boolean, score?: number) {
-  if (empty)                                  return "border-l-amber-500/60";
-  if (score !== undefined && score < 60)      return "border-l-red-500/50";
-  if (score !== undefined && score < 80)      return "border-l-yellow-500/50";
-  if (score !== undefined && score >= 80)     return "border-l-emerald-500/40";
+  if (empty)                              return "border-l-amber-500/60";
+  if (score !== undefined && score < 60)  return "border-l-red-500/50";
+  if (score !== undefined && score < 80)  return "border-l-yellow-500/50";
+  if (score !== undefined && score >= 80) return "border-l-emerald-500/40";
   return "border-l-border";
 }
 
 function getInputStyle(empty: boolean, score?: number) {
-  if (empty)                                  return "border-amber-500/40 bg-amber-500/5 dark:bg-amber-500/[0.06]";
-  if (score !== undefined && score < 60)      return "border-red-400/60 dark:border-red-500/50";
+  if (empty)                              return "border-amber-500/40 bg-amber-500/5 dark:bg-amber-500/[0.06]";
+  if (score !== undefined && score < 60)  return "border-red-400/60 dark:border-red-500/50";
   return "";
 }
 
@@ -107,17 +113,18 @@ export default function PassportFieldsForm({
 
       <p className="text-xs text-muted-foreground">{t("reviewDescription")}</p>
 
-      {/* Fields */}
-      <div className="space-y-2">
+      {/* 2-column grid — wide fields span both columns */}
+      <div className="grid grid-cols-2 gap-x-4 gap-y-2">
         {sorted.map((field) => {
           const value = values[field.key] || "";
           const empty = !value.trim();
           const score = confidence?.[field.key];
+          const wide = isWideField(field.key);
 
           return (
             <div
               key={field.key}
-              className={`border-l-2 pl-3 py-0.5 transition-colors ${getFieldAccent(empty, score)}`}
+              className={`border-l-2 pl-3 py-0.5 transition-colors ${getFieldAccent(empty, score)} ${wide ? "col-span-2" : "col-span-1"}`}
             >
               <div className="flex items-center gap-2 mb-1">
                 <label className="text-xs font-medium">{field.label}</label>

--- a/src/features/passport/components/PassportPage.tsx
+++ b/src/features/passport/components/PassportPage.tsx
@@ -309,8 +309,9 @@ export default function PassportPage() {
               </div>
             </div>
 
-            {/* Col 2: original document (top) + live DOCX preview (below) */}
-            <div className="lg:col-span-1 space-y-4">
+            {/* Col 2: sticky panel — stays in view while user scrolls fields */}
+            <div className="lg:col-span-1 lg:sticky lg:top-4 lg:self-start">
+              <div className="space-y-4 lg:max-h-[calc(100vh-6rem)] lg:overflow-y-auto lg:pr-1 [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-muted-foreground/20 [&::-webkit-scrollbar-thumb:hover]:bg-muted-foreground/40">
               {/* Original uploaded document */}
               <div className="rounded-xl border bg-muted/30 overflow-hidden">
                 <div className="flex items-center justify-between px-3 py-2 border-b bg-background/60">
@@ -364,6 +365,7 @@ export default function PassportPage() {
                 docxUrl={selectedTemplate.docx_file_url}
                 fields={fieldValues}
               />
+            </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- **2-column field grid**: fields now sit in a responsive 2-col layout, cutting form height ~50%. Wide fields (names, MRZ lines, places, authority) span both columns; short fields (type, sex, dates, country code) share a row.
- **Sticky right panel**: the original document + DOCX preview column sticks to the viewport as the user scrolls through fields. It scrolls internally when the content exceeds the viewport height, with a thin custom scrollbar.

## Layout logic
Wide (col-span-2): keys matching `mrz`, `surname`, `given_names`, `place_of_birth`, `authority`, `personal_number`  
Half-width (col-span-1): everything else (type, country_code, passport_number, sex, nationality, dates, height)

## Test plan
- [ ] Review step: fields appear in 2 columns — short fields pair up, name/MRZ fields span full width
- [ ] Scroll down the field list — right panel (passport image + preview) stays pinned at the top
- [ ] When DOCX preview is generated and tall, the right panel scrolls internally without affecting page scroll
- [ ] On mobile (single column), layout collapses back to 1-column; sticky behaviour disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)