### PR TITLE
feat: Get Suggestions button in history document empty state

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -531,6 +531,7 @@
     "cancel": "Cancel",
     "reject": "Reject",
     "editPlaceholder": "Edit suggestion text...",
+    "getSuggestions": "Get Suggestions",
     "retrySuggestions": "Retry Suggestions",
     "previewTitle": "Suggestion Preview",
     "showPreview": "Show preview",

--- a/messages/ka.json
+++ b/messages/ka.json
@@ -529,6 +529,7 @@
     "cancel": "გაუქმება",
     "reject": "უარყოფა",
     "editPlaceholder": "შეცვალეთ შემოთავაზებული ტექსტი...",
+    "getSuggestions": "შემოთავაზებების მიღება",
     "retrySuggestions": "შემოთავაზებების თავიდან ცდა",
     "previewTitle": "წინასწარი ნახვა",
     "showPreview": "წინასწარი ნახვა",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -527,6 +527,7 @@
     "accept": "Zaakceptuj",
     "reject": "Odrzuć",
     "editPlaceholder": "Edytuj sugerowany tekst...",
+    "getSuggestions": "Pobierz sugestie",
     "retrySuggestions": "Ponów sugestie",
     "showPreview": "Pokaż podgląd",
     "hidePreview": "Ukryj podgląd",

--- a/src/features/chatHistory/components/ChatSuggestionsPanel.tsx
+++ b/src/features/chatHistory/components/ChatSuggestionsPanel.tsx
@@ -1,4 +1,4 @@
-import { Check, X, Copy } from "lucide-react";
+import { Check, X, Copy, Sparkles, Loader2 } from "lucide-react";
 import { useState } from "react";
 import { ApplySuggestionResponse, Suggestion } from "@/features/translation";
 import { useChatSuggestionsStore } from "../store/chatSuggestionsStore";
@@ -44,6 +44,22 @@ const ChatSuggestionsPanel: React.FC<ChatSuggestionsPanelProps> = ({
 
   const [loadingSuggestionId, setLoadingSuggestionId] = useState<string | null>(null);
   const [previewSuggestionId, setPreviewSuggestionId] = useState<string | null>(null);
+  const [isGettingSuggestions, setIsGettingSuggestions] = useState(false);
+
+  const handleGetSuggestions = async () => {
+    if (!jobId || isGettingSuggestions) return;
+    setIsGettingSuggestions(true);
+    try {
+      const { settingUpChatSuggestions } = await import(
+        "@/features/chatHistory/utils/settingUpSuggestions"
+      );
+      await settingUpChatSuggestions(jobId);
+    } catch {
+      // suggestions remain empty — user can retry
+    } finally {
+      setIsGettingSuggestions(false);
+    }
+  };
   const t = useTranslations();
 
   const handleRemoveSuggestion = (id: string) => {
@@ -233,12 +249,30 @@ const ChatSuggestionsPanel: React.FC<ChatSuggestionsPanelProps> = ({
           ))}
         </div>
       ) : (
-        <div className="flex flex-col gap-4">
-          <div className="text-center text-muted-foreground">
+        <div className="flex flex-col items-center gap-3 py-6 text-center">
+          <p className="text-sm text-muted-foreground">
             {t("SuggestionsPanel.noSuggestions", {
               default: "No suggestions available.",
             })}
-          </div>
+          </p>
+          <button
+            type="button"
+            onClick={handleGetSuggestions}
+            disabled={isGettingSuggestions}
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg border hover:bg-accent transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isGettingSuggestions ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {t("SuggestionsPanel.generating", { default: "Generating..." })}
+              </>
+            ) : (
+              <>
+                <Sparkles className="h-4 w-4" />
+                {t("SuggestionsPanel.getSuggestions", { default: "Get Suggestions" })}
+              </>
+            )}
+          </button>
         </div>
       )}
       <div className="mt-3" />


### PR DESCRIPTION
## Problem
When opening a completed document from History, the suggestions panel auto-loads but may return empty (backend suggestions expired or timed out). The panel showed a static "No suggestions available." message with no way to retry — users were stuck.

## Fix
Added a **Get Suggestions** button in the empty state of `ChatSuggestionsPanel`:
- `Sparkles` icon + translated label
- Clicking triggers `settingUpChatSuggestions(jobId)` which polls the backend
- Button shows spinner + "Generating..." while in-flight
- On success: suggestions appear normally; on failure: button reappears for retry
- Local `isGettingSuggestions` state — independent of the parent's `isSuggestionsLoading`

## Test plan
- [ ] Open a completed document from History where suggestions panel shows empty
- [ ] "Get Suggestions" button is visible with Sparkles icon
- [ ] Clicking shows spinner and "Generating..." label
- [ ] If backend returns suggestions, they appear in the panel
- [ ] If backend returns empty, button reappears (retry possible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)