### PR TITLE
fix: handle 404 from suggestions endpoint gracefully

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -532,6 +532,7 @@
     "reject": "Reject",
     "editPlaceholder": "Edit suggestion text...",
     "getSuggestions": "Get Suggestions",
+    "suggestionsNotAvailable": "Suggestions are not available for this document.",
     "retrySuggestions": "Retry Suggestions",
     "previewTitle": "Suggestion Preview",
     "showPreview": "Show preview",

--- a/messages/ka.json
+++ b/messages/ka.json
@@ -530,6 +530,7 @@
     "reject": "უარყოფა",
     "editPlaceholder": "შეცვალეთ შემოთავაზებული ტექსტი...",
     "getSuggestions": "შემოთავაზებების მიღება",
+    "suggestionsNotAvailable": "ამ დოკუმენტისთვის შემოთავაზებები მიუწვდომელია.",
     "retrySuggestions": "შემოთავაზებების თავიდან ცდა",
     "previewTitle": "წინასწარი ნახვა",
     "showPreview": "წინასწარი ნახვა",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -528,6 +528,7 @@
     "reject": "Odrzuć",
     "editPlaceholder": "Edytuj sugerowany tekst...",
     "getSuggestions": "Pobierz sugestie",
+    "suggestionsNotAvailable": "Sugestie nie sa dostepne dla tego dokumentu.",
     "retrySuggestions": "Ponów sugestie",
     "showPreview": "Pokaż podgląd",
     "hidePreview": "Ukryj podgląd",

--- a/src/features/chatHistory/components/ChatSuggestionsPanel.tsx
+++ b/src/features/chatHistory/components/ChatSuggestionsPanel.tsx
@@ -45,15 +45,20 @@ const ChatSuggestionsPanel: React.FC<ChatSuggestionsPanelProps> = ({
   const [loadingSuggestionId, setLoadingSuggestionId] = useState<string | null>(null);
   const [previewSuggestionId, setPreviewSuggestionId] = useState<string | null>(null);
   const [isGettingSuggestions, setIsGettingSuggestions] = useState(false);
+  const [suggestionsNotAvailable, setSuggestionsNotAvailable] = useState(false);
 
   const handleGetSuggestions = async () => {
     if (!jobId || isGettingSuggestions) return;
     setIsGettingSuggestions(true);
+    setSuggestionsNotAvailable(false);
     try {
       const { settingUpChatSuggestions } = await import(
         "@/features/chatHistory/utils/settingUpSuggestions"
       );
-      await settingUpChatSuggestions(jobId);
+      const result = await settingUpChatSuggestions(jobId);
+      if (result === "not_found") {
+        setSuggestionsNotAvailable(true);
+      }
     } catch {
       // suggestions remain empty — user can retry
     } finally {
@@ -251,28 +256,34 @@ const ChatSuggestionsPanel: React.FC<ChatSuggestionsPanelProps> = ({
       ) : (
         <div className="flex flex-col items-center gap-3 py-6 text-center">
           <p className="text-sm text-muted-foreground">
-            {t("SuggestionsPanel.noSuggestions", {
-              default: "No suggestions available.",
-            })}
+            {suggestionsNotAvailable
+              ? t("SuggestionsPanel.suggestionsNotAvailable", {
+                  default: "Suggestions are not available for this document.",
+                })
+              : t("SuggestionsPanel.noSuggestions", {
+                  default: "No suggestions available.",
+                })}
           </p>
-          <button
-            type="button"
-            onClick={handleGetSuggestions}
-            disabled={isGettingSuggestions}
-            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg border hover:bg-accent transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {isGettingSuggestions ? (
-              <>
-                <Loader2 className="h-4 w-4 animate-spin" />
-                {t("SuggestionsPanel.generating", { default: "Generating..." })}
-              </>
-            ) : (
-              <>
-                <Sparkles className="h-4 w-4" />
-                {t("SuggestionsPanel.getSuggestions", { default: "Get Suggestions" })}
-              </>
-            )}
-          </button>
+          {!suggestionsNotAvailable && (
+            <button
+              type="button"
+              onClick={handleGetSuggestions}
+              disabled={isGettingSuggestions}
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg border hover:bg-accent transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isGettingSuggestions ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  {t("SuggestionsPanel.generating", { default: "Generating..." })}
+                </>
+              ) : (
+                <>
+                  <Sparkles className="h-4 w-4" />
+                  {t("SuggestionsPanel.getSuggestions", { default: "Get Suggestions" })}
+                </>
+              )}
+            </button>
+          )}
         </div>
       )}
       <div className="mt-3" />

--- a/src/features/chatHistory/utils/settingUpSuggestions.ts
+++ b/src/features/chatHistory/utils/settingUpSuggestions.ts
@@ -34,7 +34,11 @@ export async function settingUpChatSuggestions(jobId: string): Promise<string> {
           setSuggestions(filtered);
           return "success";
         }
+      } else if (suggestionsResponse.status === "not_found") {
+        setSuggestions([]);
+        return "not_found";
       } else if (suggestionsResponse.status === "processing") {
+        // continue polling
       } else {
         setSuggestions([]);
         return suggestionsResponse.status;

--- a/src/features/translation/services/suggestionsService.ts
+++ b/src/features/translation/services/suggestionsService.ts
@@ -65,6 +65,8 @@ export async function getSuggestions(
   } else if (response.status === 400) {
     const data = (await response.json()) as SuggestionsResponseProcessing;
     return data;
+  } else if (response.status === 404) {
+    return { status: "not_found" } as SuggestionsResponseProcessing;
   }
 
   throw new Error("Failed to fetch suggestions");


### PR DESCRIPTION
## Problem
`GET /Document/translate/suggestions/{jobId}` returns 404 when the backend has no suggestions record for that job. The frontend was throwing an unhandled error that appeared in the browser console, and the "Get Suggestions" button would reappear allowing pointless retries.

## Root cause
`suggestionsService.ts` threw `new Error("Failed to fetch suggestions")` for any non-200/400 response, including 404. The catch block in `settingUpChatSuggestions` swallowed it and returned `"empty"`, but the button still showed — inviting the user to retry something that will always 404.

## Fix
Three-layer change:
1. **`suggestionsService.ts`** — return `{ status: "not_found" }` on 404 instead of throwing; no console error
2. **`settingUpChatSuggestions`** — detect `"not_found"` and return immediately; no 40-attempt retry loop
3. **`ChatSuggestionsPanel`** — when result is `"not_found"`, set `suggestionsNotAvailable = true`; show "Suggestions are not available for this document." and hide the Get Suggestions button

## UX before / after
| Scenario | Before | After |
|----------|--------|-------|
| Suggestions 404 | Console error + button reappears | No console error, clear message, button hidden |
| Suggestions processing | Polls 40× | Unchanged |
| Suggestions found | Shows them | Unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)