### PR TITLE
feat: regenerate suggestions when all previous ones are dismissed

### DIFF
--- a/src/features/chatHistory/components/ChatSuggestionsPanel.tsx
+++ b/src/features/chatHistory/components/ChatSuggestionsPanel.tsx
@@ -55,9 +55,26 @@ const ChatSuggestionsPanel: React.FC<ChatSuggestionsPanelProps> = ({
       const { settingUpChatSuggestions } = await import(
         "@/features/chatHistory/utils/settingUpSuggestions"
       );
+      // First, try fetching already-stored suggestions
       const result = await settingUpChatSuggestions(jobId);
+      if (result === "success") return;
       if (result === "not_found") {
         setSuggestionsNotAvailable(true);
+        return;
+      }
+      // "empty" — no unreturned suggestions left; regenerate via backend
+      if (chatId && currentTargetLanguageId) {
+        const { regenerateSuggestions } = await import(
+          "@/features/translation/services/suggestionsService"
+        );
+        await regenerateSuggestions({
+          jobId,
+          chatId,
+          targetLanguageId: currentTargetLanguageId,
+          outputLanguageId: currentTargetLanguageId,
+        });
+        // Poll with retries — background generation needs time
+        await settingUpChatSuggestions(jobId, { waitForNew: true });
       }
     } catch {
       // suggestions remain empty — user can retry

--- a/src/features/chatHistory/utils/settingUpSuggestions.ts
+++ b/src/features/chatHistory/utils/settingUpSuggestions.ts
@@ -14,7 +14,7 @@ function isSuggestionsResponse(
   );
 }
 
-export async function settingUpChatSuggestions(jobId: string): Promise<string> {
+export async function settingUpChatSuggestions(jobId: string, options?: { waitForNew?: boolean }): Promise<string> {
   const { setSuggestions } = useChatSuggestionsStore.getState();
   const maxAttempts = 40;
   const delayMs = 3000;
@@ -34,6 +34,12 @@ export async function settingUpChatSuggestions(jobId: string): Promise<string> {
           setSuggestions(filtered);
           return "success";
         }
+        if (!options?.waitForNew) {
+          // Server responded with 0 suggestions and we're not waiting for new ones
+          setSuggestions([]);
+          return "empty";
+        }
+        // waitForNew=true: keep polling — background generation may still be running
       } else if (suggestionsResponse.status === "not_found") {
         setSuggestions([]);
         return "not_found";

--- a/src/features/translation/services/suggestionsService.ts
+++ b/src/features/translation/services/suggestionsService.ts
@@ -129,3 +129,52 @@ export async function applySuggestion(params: ApplySuggestionParams): Promise<Ap
 
     throw new Error("Failed to apply suggestion");
 }
+
+export async function regenerateSuggestions(params: {
+  jobId: string;
+  chatId: string;
+  targetLanguageId: number;
+  outputLanguageId: number;
+}): Promise<void> {
+  const endpoint = `/Document/translate/suggestions/regenerate/${params.jobId}`;
+  const { token, refreshToken } = useAuthStore.getState();
+
+  const headers = new Headers();
+  if (token && typeof token === "string" && token.trim()) {
+    headers.append("Authorization", `Bearer ${token.replace(/[\r\n\t]/g, "").trim()}`);
+    headers.append("Content-Type", "application/json");
+  } else {
+    throw new Error("No valid token found");
+  }
+
+  const body = JSON.stringify({
+    chatId: params.chatId,
+    targetLanguageId: params.targetLanguageId,
+    outputLanguageId: params.outputLanguageId,
+  });
+
+  let response = await fetch(`${API_BASE_URL}${endpoint}`, { method: "POST", headers, body });
+
+  if (response.status === 401 && token && refreshToken) {
+    try {
+      const newTokens = (await reaccessToken(refreshToken)) as { token: string; refreshToken: string };
+      const { setToken, setRefreshToken } = useAuthStore.getState();
+      setToken(newTokens.token);
+      setRefreshToken(newTokens.refreshToken);
+      const sanitized = newTokens.token?.replace(/[\r\n\t]/g, "").trim();
+      if (sanitized) {
+        headers.set("Authorization", `Bearer ${sanitized}`);
+        response = await fetch(`${API_BASE_URL}${endpoint}`, { method: "POST", headers, body });
+      } else {
+        throw new Error("Invalid refreshed token");
+      }
+    } catch {
+      useAuthStore.getState().reset();
+      throw new Error("Token refresh failed");
+    }
+  }
+
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error("Failed to regenerate suggestions");
+  }
+}


### PR DESCRIPTION
## Summary
- "Get Suggestions" button now performs a fast GET check first; if all suggestions are already exhausted it calls the new `POST /suggestions/regenerate` endpoint, then polls with retries for the freshly generated ones
- `settingUpChatSuggestions` returns `"empty"` immediately when the server responds with 0 suggestions (prevents a 120-second retry loop); a new `waitForNew: true` option keeps the retry behaviour when explicitly waiting for background generation to finish
- Adds `regenerateSuggestions()` to `suggestionsService.ts` for the new backend endpoint

## Test plan
- [ ] Opening a history doc with no suggestions → click "Get Suggestions" → existing stored suggestions appear
- [ ] Dismiss all suggestions → click "Get Suggestions" again → regeneration triggers, spinner shows, new suggestions appear after AI finishes
- [ ] Job-not-found case still shows "Suggestions not available" and hides the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)