### PR TITLE
fix: always attempt regeneration when no suggestions are available

### DIFF
--- a/src/features/chatHistory/components/ChatSuggestionsPanel.tsx
+++ b/src/features/chatHistory/components/ChatSuggestionsPanel.tsx
@@ -52,30 +52,35 @@ const ChatSuggestionsPanel: React.FC<ChatSuggestionsPanelProps> = ({
     setIsGettingSuggestions(true);
     setSuggestionsNotAvailable(false);
     try {
-      const { settingUpChatSuggestions } = await import(
-        "@/features/chatHistory/utils/settingUpSuggestions"
-      );
-      // First, try fetching already-stored suggestions
-      const result = await settingUpChatSuggestions(jobId);
-      if (result === "success") return;
-      if (result === "not_found") {
+      const [{ settingUpChatSuggestions }, { regenerateSuggestions }] = await Promise.all([
+        import("@/features/chatHistory/utils/settingUpSuggestions"),
+        import("@/features/translation/services/suggestionsService"),
+      ]);
+
+      // Try fetching already-stored, unreturned suggestions first
+      const fetchResult = await settingUpChatSuggestions(jobId);
+      if (fetchResult === "success") return;
+
+      // Nothing found (empty or job record missing) — kick off (re)generation
+      if (!chatId || !currentTargetLanguageId) {
         setSuggestionsNotAvailable(true);
         return;
       }
-      // "empty" — no unreturned suggestions left; regenerate via backend
-      if (chatId && currentTargetLanguageId) {
-        const { regenerateSuggestions } = await import(
-          "@/features/translation/services/suggestionsService"
-        );
+
+      try {
         await regenerateSuggestions({
           jobId,
           chatId,
           targetLanguageId: currentTargetLanguageId,
           outputLanguageId: currentTargetLanguageId,
         });
-        // Poll with retries — background generation needs time
-        await settingUpChatSuggestions(jobId, { waitForNew: true });
+      } catch {
+        setSuggestionsNotAvailable(true);
+        return;
       }
+
+      // Poll with retries until the background generation finishes
+      await settingUpChatSuggestions(jobId, { waitForNew: true });
     } catch {
       // suggestions remain empty — user can retry
     } finally {


### PR DESCRIPTION
## Summary
- "Get Suggestions" no longer gives up on `not_found` — it now attempts `POST /regenerate` for both `empty` and `not_found` fetch results
- Only if the regeneration POST itself fails (job truly gone from DB) is the "not available" state shown
- Eager-loads both imports in parallel via `Promise.all` to shave a tick off the cold path

## Test plan
- [ ] Opening a history doc with no suggestions → click "Get Suggestions" → regeneration fires, spinner shows, suggestions appear
- [ ] Dismissing all suggestions → click "Get Suggestions" → same flow
- [ ] Job with expired/missing DB record → POST fails → "Suggestions not available" shown correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)