### PR TITLE
feat: 1-month cross-device preview for original documents

### DIFF
--- a/src/features/chatHistory/services/chatService.ts
+++ b/src/features/chatHistory/services/chatService.ts
@@ -288,6 +288,34 @@ export const getSingleChatHistoryOriginalFile = async (
 };
 
 /**
+ * Upload the original source file for a chat so it can be previewed later on any device.
+ * URI-based (Gemini Files API) translations don't send the file bytes to the backend during
+ * translation, so we store them separately here. The backend keeps them for ~1 month.
+ */
+export const uploadOriginalForChat = async (
+  chatId: string,
+  file: File
+): Promise<void> => {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const response = await fetchWithAuth(
+    `/document-translation/chat/${chatId}/file`,
+    {
+      method: "POST",
+      body: formData,
+    }
+  );
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(
+      errorData.Message || errorData.message || "Failed to store original document"
+    );
+  }
+};
+
+/**
  * Update chat document content
  */
 export const updateChatDocumentContent = async (

--- a/src/features/translation/components/DocumentTranslationCard.tsx
+++ b/src/features/translation/components/DocumentTranslationCard.tsx
@@ -28,7 +28,7 @@ import { useSearchParams } from "next/navigation";
 import ErrorAlert from "@/shared/components/ErrorAlert";
 import { EmailPromptModal } from "@/shared/components/EmailPromptModal";
 import { startTranslationProject } from "../utils/startTranslationProject";
-import { moveChatToProject } from "@/features/chatHistory";
+import { moveChatToProject, uploadOriginalForChat } from "@/features/chatHistory";
 // DISABLED: Unused import - Splitting functionality is kept in repository but not used
 // import { extractPagesFromDocument } from "../utils/extractPages";
 import { saveFileToStorage, getFileFromStorage, clearFileFromStorage, getMetadataFromStorage, saveOriginalFileForChat, type DocumentMetadata } from "@/shared/utils/fileStorage";
@@ -508,10 +508,16 @@ const DocumentTranslationCard = () => {
 
       const { chatId } = await startTranslationProject(data, estimatedPageCount || 1);
 
-      // Persist the original file so the translation detail page can show the preview
-      // (URI-based translations don't store bytes on the backend)
-      if (!data.isSrt && typeof window !== 'undefined' && 'indexedDB' in window) {
-        saveOriginalFileForChat(chatId, data.currentFile[0]).catch(() => {});
+      // Persist the original file so the translation detail page can show the preview.
+      // URI-based (Gemini) translations don't store bytes on the backend during translation,
+      // so we persist them in two places:
+      if (!data.isSrt) {
+        // 1. Server-side copy — visible on any device for ~1 month (primary preview source).
+        uploadOriginalForChat(chatId, data.currentFile[0]).catch(() => {});
+        // 2. Browser-local copy — instant preview in this browser until cache is cleared.
+        if (typeof window !== 'undefined' && 'indexedDB' in window) {
+          saveOriginalFileForChat(chatId, data.currentFile[0]).catch(() => {});
+        }
       }
       // Also update the in-memory store so the translation page can use it instantly
       useDocumentTranslationStore.getState().setChatId(chatId);


### PR DESCRIPTION
## Problem
For non-SRT documents we upload to the **Gemini Files API** and only send the backend a `fileUri` — never the bytes. Gemini deletes files after **48h**, and the only long-lived copy of the original lived in the uploading browser's IndexedDB. So the original preview disappeared after a while / on another device / after a cache clear.

## Change
After a URI-based translation starts, upload the original to the new backend endpoint **`POST /document-translation/chat/{chatId}/file`** (paired with backend PR). The translation detail page already fetches `GET .../{chatId}/file` first, so the preview now works on **any device for ~1 month**. IndexedDB remains as an instant local cache.

- `chatService.ts` — new `uploadOriginalForChat(chatId, file)`
- `DocumentTranslationCard.tsx` — fire-and-forget upload alongside the existing IndexedDB save (never blocks/fails the translation)

## Notes
- Requires the backend PR (new endpoint + 30-day purge). Without it the upload just no-ops via `.catch`.
- Type-check clean (pre-existing `@dnd-kit` module errors are unrelated/local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)