### PR TITLE
feat: force HTML output format for document translations

### DIFF
--- a/src/features/translation/types/types.Translation.ts
+++ b/src/features/translation/types/types.Translation.ts
@@ -1,5 +1,8 @@
 export type TranslationResult = string | null;
 
+/** DocumentFormat.Html — forced so the editor exercises the HTML render path. Set back to 0 to revert. */
+export const DEFAULT_DOCUMENT_OUTPUT_FORMAT = 5;
+
 export interface TextTranslateUserContentParams {
   UserText: string;
   LanguageId: number;

--- a/src/features/translation/utils/documentTranslation.ts
+++ b/src/features/translation/utils/documentTranslation.ts
@@ -1,5 +1,5 @@
 import { translateDocumentUserContent, translateDocumentWithUri } from "../services/translationService";
-import { DocumentTranslateUserContentParams } from "../types/types.Translation";
+import { DocumentTranslateUserContentParams, DEFAULT_DOCUMENT_OUTPUT_FORMAT } from "../types/types.Translation";
 import { uploadFileToGemini } from "../services/geminiUploadService";
 import { useDocumentTranslationStore } from "../store/documentTranslationStore";
 import { getResult, getStatus } from "../services/jobService";
@@ -56,7 +56,7 @@ export async function documentTranslatingWithJobId(
       fileName: file.name,
       TargetLanguageId: data.currentTargetLanguageId,
       OutputLanguageId: outputLanguageId,
-      OutputFormat: 0,
+      OutputFormat: DEFAULT_DOCUMENT_OUTPUT_FORMAT,
       model: model,
     });
   }

--- a/src/features/translation/utils/startTranslationProject.ts
+++ b/src/features/translation/utils/startTranslationProject.ts
@@ -1,5 +1,5 @@
 import { translateDocumentUserContent, translateDocumentWithUri } from "../services/translationService";
-import { DocumentTranslateUserContentParams, NameTranslationItem } from "../types/types.Translation";
+import { DocumentTranslateUserContentParams, NameTranslationItem, DEFAULT_DOCUMENT_OUTPUT_FORMAT } from "../types/types.Translation";
 import { DocumentFormData } from "../components/DocumentTranslationCard";
 import { uploadFileToGemini } from "../services/geminiUploadService";
 
@@ -40,7 +40,7 @@ export async function startTranslationProject(
       fileName: data.currentFile[0].name,
       TargetLanguageId: data.currentTargetLanguageId,
       OutputLanguageId: outputLanguageId,
-      OutputFormat: 0,
+      OutputFormat: DEFAULT_DOCUMENT_OUTPUT_FORMAT,
       model,
       pageCount: pageCount ?? 1,
       nameTranslations: confirmedNames && confirmedNames.length > 0 ? confirmedNames : undefined,


### PR DESCRIPTION
## What

Forces non-SRT document translations to request `OutputFormat=5` (`DocumentFormat.Html`) via a single shared constant `DEFAULT_DOCUMENT_OUTPUT_FORMAT`, used at both call sites ([`startTranslationProject.ts`](src/features/translation/utils/startTranslationProject.ts), [`documentTranslation.ts`](src/features/translation/utils/documentTranslation.ts)). SRT stays at `0`.

The TipTap editor already renders content as HTML when it starts with `<`, so no editor changes are needed.

## Why

To exercise the editor's HTML render path end-to-end against backend-produced HTML. Pairs with backend PR goga0301/Api24.ContentAI#73 (already merged), which makes `translate-with-uri` return `text/html` for `OutputFormat=5`.

## Notes

- **Deployment ordering:** harmless if this ships before the backend is live — the old backend ignores `OutputFormat` and returns markdown, which the editor still handles.
- **Revert:** set `DEFAULT_DOCUMENT_OUTPUT_FORMAT` back to `0`.
- Typechecks clean (`tsc --noEmit` shows only pre-existing unrelated errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)