### PR TITLE
feat: add selectable output format with Rich PDF option

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -399,6 +399,10 @@
     "translatedText": "Translated Text",
     "sourceLanguage": "Source Language",
     "targetLanguage": "Target Language",
+    "outputFormat": "Output format",
+    "outputFormatHtml": "HTML",
+    "outputFormatRichPdf": "Rich PDF",
+    "outputFormatMarkdown": "Markdown",
     "ocrOnly": "OCR Only",
     "progress": {
       "longerThanUsual": "Takes longer than usual",

--- a/messages/ka.json
+++ b/messages/ka.json
@@ -417,6 +417,10 @@
     "translatedText": "თარგმნილი ტექსტი",
     "sourceLanguage": "საწყისი ენა",
     "targetLanguage": "სამიზნე ენა",
+    "outputFormat": "გამომავალი ფორმატი",
+    "outputFormatHtml": "HTML",
+    "outputFormatRichPdf": "Rich PDF",
+    "outputFormatMarkdown": "Markdown",
     "ocrOnly": "მხოლოდ OCR",
     "progress": {
       "longerThanUsual": "სჭირდება იმაზე მეტი დრო, ვიდრე ველოდით",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -415,6 +415,10 @@
     "translatedText": "Przetłumaczony tekst",
     "sourceLanguage": "Język źródłowy",
     "targetLanguage": "Język docelowy",
+    "outputFormat": "Format wyjściowy",
+    "outputFormatHtml": "HTML",
+    "outputFormatRichPdf": "Rich PDF",
+    "outputFormatMarkdown": "Markdown",
     "progress": {
       "longerThanUsual": "Trwa to dłużej niż zwykle",
       "starting": "Rozpoczynanie tłumaczenia...",

--- a/src/features/translation/components/DocumentTranslationCard.tsx
+++ b/src/features/translation/components/DocumentTranslationCard.tsx
@@ -30,7 +30,7 @@ import { EmailPromptModal } from "@/shared/components/EmailPromptModal";
 import { startTranslationProject } from "../utils/startTranslationProject";
 import { suggestNameTranslations } from "../services/nameTranslationService";
 import NameReviewModal from "./NameReviewModal";
-import { NameTranslationItem } from "../types/types.Translation";
+import { NameTranslationItem, DEFAULT_DOCUMENT_OUTPUT_FORMAT } from "../types/types.Translation";
 import { moveChatToProject, uploadOriginalForChat } from "@/features/chatHistory";
 import { getProjectNames, saveProjectNames, type ProjectNameTranslation } from "@/features/projects";
 // DISABLED: Unused import - Splitting functionality is kept in repository but not used
@@ -38,6 +38,7 @@ import { getProjectNames, saveProjectNames, type ProjectNameTranslation } from "
 import { saveFileToStorage, getFileFromStorage, clearFileFromStorage, getMetadataFromStorage, saveOriginalFileForChat, type DocumentMetadata } from "@/shared/utils/fileStorage";
 import LanguageSelect from "./LanguageSelect";
 import { Button } from "@/features/ui/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/features/ui/components/ui/select";
 import { ArrowRightLeft } from "lucide-react";
 import { countPages } from "@/features/translation/services/countPagesService";
 import { useSuggestionsStore } from "../store/suggestionsStore";
@@ -153,6 +154,8 @@ const DocumentTranslationCard = () => {
   } = useDocumentTranslationStore();
   const [isButtonHighlighted, setIsButtonHighlighted] = useState(false);
   const [isOcrOnly, setIsOcrOnly] = useState(false);
+  // Output format for document (non-SRT) translations. Defaults to the standard HTML output.
+  const [outputFormat, setOutputFormat] = useState<number>(DEFAULT_DOCUMENT_OUTPUT_FORMAT);
   const [isDetectingNames, setIsDetectingNames] = useState(false);
   const [showNameModal, setShowNameModal] = useState(false);
   const [detectedNames, setDetectedNames] = useState<NameTranslationItem[]>([]);
@@ -218,6 +221,7 @@ const DocumentTranslationCard = () => {
     formState: { errors },
     setValue,
     clearErrors,
+    watch,
   } = useForm<DocumentFormData>({
     resolver: zodResolver(documentTranslationSchema),
     defaultValues: {
@@ -635,7 +639,7 @@ const DocumentTranslationCard = () => {
       //   setValue("currentFile", newFileList);
       // }
 
-      const { chatId } = await startTranslationProject(data, estimatedPageCount || 1, reviewedNames);
+      const { chatId } = await startTranslationProject(data, estimatedPageCount || 1, reviewedNames, outputFormat);
 
       // Persist the original file so the translation detail page can show the preview.
       // URI-based (Gemini) translations don't store bytes on the backend during translation,
@@ -926,6 +930,22 @@ const DocumentTranslationCard = () => {
                       onChange={setCurrentTargetLanguageId}
                     />
                   </div>
+                </div>
+              )}
+              {/* Output format (document / non-SRT translations) */}
+              {!isOcrOnly && !watch("isSrt") && (
+                <div className="mb-4 sm:max-w-xs">
+                  <span className="block text-xs text-muted-foreground mb-1">{t("outputFormat")}</span>
+                  <Select value={String(outputFormat)} onValueChange={(v) => setOutputFormat(Number(v))}>
+                    <SelectTrigger className="h-10">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="5">{t("outputFormatHtml")}</SelectItem>
+                      <SelectItem value="6">{t("outputFormatRichPdf")}</SelectItem>
+                      <SelectItem value="2">{t("outputFormatMarkdown")}</SelectItem>
+                    </SelectContent>
+                  </Select>
                 </div>
               )}
               {translatedMarkdown ? (

--- a/src/features/translation/utils/startTranslationProject.ts
+++ b/src/features/translation/utils/startTranslationProject.ts
@@ -11,7 +11,8 @@ import { uploadFileToGemini } from "../services/geminiUploadService";
 export async function startTranslationProject(
   data: DocumentFormData,
   pageCount?: number,
-  confirmedNames?: NameTranslationItem[]
+  confirmedNames?: NameTranslationItem[],
+  outputFormat: number = DEFAULT_DOCUMENT_OUTPUT_FORMAT
 ): Promise<{ jobId: string; chatId: string }> {
   const model = 2;
   const outputLanguageId =
@@ -40,7 +41,7 @@ export async function startTranslationProject(
       fileName: data.currentFile[0].name,
       TargetLanguageId: data.currentTargetLanguageId,
       OutputLanguageId: outputLanguageId,
-      OutputFormat: DEFAULT_DOCUMENT_OUTPUT_FORMAT,
+      OutputFormat: outputFormat,
       model,
       pageCount: pageCount ?? 1,
       nameTranslations: confirmedNames && confirmedNames.length > 0 ? confirmedNames : undefined,


### PR DESCRIPTION
## What

Adds an **output-format selector** (HTML / Rich PDF / Markdown) to the document translation form ([`DocumentTranslationCard.tsx`](src/features/translation/components/DocumentTranslationCard.tsx)), shown for non-SRT / non-OCR documents. The choice is threaded through [`startTranslationProject`](src/features/translation/utils/startTranslationProject.ts) → `translate-with-uri` as `OutputFormat`.

- Defaults to the current `DEFAULT_DOCUMENT_OUTPUT_FORMAT` (HTML=5) — **no behaviour change unless the user picks a format**.
- **Rich PDF (6)** returns editor-editable HTML that reconstructs the source layout; the editor already renders it and can export to PDF.
- Selector labels added to `en` / `ka` / `pl` locales.

## Why

Exposes the new backend Rich PDF reconstruction (goga0301/Api24.ContentAI#74, merged) as a user-selectable option.

## Notes

- Returns `text/html`, so the editor + export paths are unchanged.
- **Deployment ordering:** harmless if this ships before the backend is live — the old backend ignores `OutputFormat=6` and returns markdown/HTML.
- Typechecks clean (`tsc --noEmit`, only pre-existing unrelated errors); all locale JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)