### PR TITLE
feat: bulk folder translation, and send uploads straight to Google

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -551,6 +551,7 @@
     "moveToRoot": "Move to root",
     "backToProjects": "All Projects",
     "addTranslation": "Add Translation",
+    "bulkTranslate": "Bulk translate",
     "status": {
       "Completed": "Completed",
       "InProgress": "Processing",

--- a/messages/ka.json
+++ b/messages/ka.json
@@ -549,6 +549,7 @@
     "moveToRoot": "მთავარში გადატანა",
     "backToProjects": "ყველა პროექტი",
     "addTranslation": "თარგმანის დამატება",
+    "bulkTranslate": "მასობრივი თარგმნა",
     "status": {
       "Completed": "დასრულებული",
       "InProgress": "მუშავდება",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -546,6 +546,7 @@
     "moveToRoot": "Przenieś do głównego widoku",
     "backToProjects": "Wszystkie projekty",
     "addTranslation": "Dodaj tłumaczenie",
+    "bulkTranslate": "Tłumaczenie zbiorcze",
     "status": {
       "Completed": "Zakończone",
       "InProgress": "Przetwarzanie",

--- a/src/app/[locale]/(main)/projects/[projectId]/bulk/page.tsx
+++ b/src/app/[locale]/(main)/projects/[projectId]/bulk/page.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { ChevronLeft, Layers } from "lucide-react";
+import { Link } from "@/i18n/navigation";
+import { Skeleton } from "@/features/ui/components/ui/skeleton";
+import { getProjectById } from "@/features/projects";
+import { BulkTranslationPanel } from "@/features/bulkTranslation";
+import { useDocumentTitle } from "@/shared/hooks/useDocumentTitle";
+
+export default function BulkTranslationPage() {
+  const params = useParams();
+  const projectId = Array.isArray(params.projectId)
+    ? params.projectId[0]
+    : params.projectId;
+
+  const [projectName, setProjectName] = useState<string>("");
+  const [loading, setLoading] = useState(true);
+
+  useDocumentTitle(projectName ? `Bulk translation — ${projectName}` : "Bulk translation");
+
+  useEffect(() => {
+    if (!projectId) return;
+
+    getProjectById(projectId)
+      .then((response) => setProjectName(response.data.name))
+      .catch(() => setProjectName(""))
+      .finally(() => setLoading(false));
+  }, [projectId]);
+
+  if (!projectId) return null;
+
+  return (
+    <div className="container mx-auto max-w-4xl p-6">
+      <Link
+        href={`/projects/${projectId}`}
+        className="-mx-1 mb-4 inline-flex items-center gap-1.5 rounded px-1 py-0.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        Back to project
+      </Link>
+
+      <div className="mb-8 flex items-center gap-3">
+        <div className="shrink-0 rounded-lg bg-suliko-default-color/10 p-2.5">
+          <Layers className="h-5 w-5 text-suliko-default-color" />
+        </div>
+        <div className="min-w-0">
+          <h1 className="truncate text-2xl font-semibold tracking-tight">
+            Bulk translation
+          </h1>
+          {loading ? (
+            <Skeleton className="mt-1 h-4 w-32" />
+          ) : (
+            projectName && (
+              <p className="truncate text-sm text-muted-foreground">{projectName}</p>
+            )
+          )}
+        </div>
+      </div>
+
+      <BulkTranslationPanel projectId={projectId} projectName={projectName} />
+    </div>
+  );
+}

--- a/src/app/[locale]/(main)/projects/[projectId]/page.tsx
+++ b/src/app/[locale]/(main)/projects/[projectId]/page.tsx
@@ -11,7 +11,7 @@ import {
   useSensors,
   type DragEndEvent,
 } from "@dnd-kit/core";
-import { ChevronLeft, AlertCircle, BookText, Folder, Pencil, Plus, Trash2 } from "lucide-react";
+import { ChevronLeft, AlertCircle, BookText, Folder, Layers, Pencil, Plus, Trash2 } from "lucide-react";
 import { Link, useRouter } from "@/i18n/navigation";
 import { Button } from "@/features/ui/components/ui/button";
 import { Card } from "@/features/ui/components/ui/card";
@@ -178,6 +178,12 @@ export default function ProjectDetailPage() {
             <h1 className="text-2xl font-semibold tracking-tight truncate">{project.name}</h1>
           </div>
           <div className="flex items-center gap-2 shrink-0">
+            <Button asChild size="sm" variant="outline" className="gap-2">
+              <Link href={`/projects/${project.id}/bulk`}>
+                <Layers className="h-4 w-4" />
+                {t("bulkTranslate")}
+              </Link>
+            </Button>
             <Button asChild size="sm" className="gap-2">
               <Link
                 href={{

--- a/src/app/api/gemini-upload/route.ts
+++ b/src/app/api/gemini-upload/route.ts
@@ -1,9 +1,24 @@
 import { NextRequest, NextResponse } from "next/server";
+import { API_BASE_URL } from "@/shared/constants/api";
 
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
 const GEMINI_UPLOAD_URL =
   "https://generativelanguage.googleapis.com/upload/v1beta/files";
+const GEMINI_UPLOAD_HOST = "generativelanguage.googleapis.com";
 
+/**
+ * This route only *opens* a Gemini resumable upload session; the browser then sends the
+ * file bytes straight to Google. It deliberately never receives the file itself.
+ *
+ * Proxying the bytes through here used to fail for anything over ~4.5MB: Vercel caps a
+ * serverless function's request body at that size and rejects it at the edge with a 413
+ * before this handler ever runs. (`serverActions.bodySizeLimit` in next.config.ts does not
+ * apply to route handlers.) Uploading direct-to-Google removes that ceiling entirely and
+ * skips a full extra copy of every file.
+ *
+ * The session URL Google returns is safe to hand to the browser: it authenticates the
+ * upload on its own and carries no API key. We assert that below rather than trusting it.
+ */
 export async function POST(request: NextRequest) {
   if (!GEMINI_API_KEY) {
     return NextResponse.json(
@@ -12,23 +27,58 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  let formData: FormData;
+  // Opening a session spends Suliko's Gemini quota, so it requires a real logged-in user.
+  const authorization = request.headers.get("authorization");
+  if (!authorization?.startsWith("Bearer ")) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
+
+  let subscriptionCheck: Response;
   try {
-    formData = await request.formData();
+    subscriptionCheck = await fetch(`${API_BASE_URL}/Subscription/me`, {
+      headers: { Authorization: authorization },
+      cache: "no-store",
+    });
   } catch {
-    return NextResponse.json({ error: "Invalid form data" }, { status: 400 });
+    return NextResponse.json(
+      { error: "Could not verify authentication" },
+      { status: 502 }
+    );
   }
 
-  const file = formData.get("file") as File | null;
-  if (!file) {
-    return NextResponse.json({ error: "No file provided" }, { status: 400 });
+  if (!subscriptionCheck.ok) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
   }
 
-  const mimeType = file.type || "application/octet-stream";
-  const displayName = file.name;
-  const fileBuffer = await file.arrayBuffer();
+  // Legacy path: the client falls back to proxying bytes through here if it cannot reach
+  // Google directly (e.g. the browser blocks the cross-origin upload). Only works below
+  // Vercel's ~4.5MB body cap, which is exactly why it is the fallback and not the default.
+  if (request.headers.get("content-type")?.includes("multipart/form-data")) {
+    return proxyUpload(request);
+  }
 
-  // Start resumable upload session
+  let body: { fileName?: string; mimeType?: string; sizeBytes?: number };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const displayName = body.fileName?.trim();
+  const mimeType = body.mimeType?.trim() || "application/octet-stream";
+  const sizeBytes = body.sizeBytes;
+
+  if (!displayName) {
+    return NextResponse.json({ error: "fileName is required" }, { status: 400 });
+  }
+
+  if (typeof sizeBytes !== "number" || !Number.isFinite(sizeBytes) || sizeBytes <= 0) {
+    return NextResponse.json(
+      { error: "sizeBytes must be a positive number" },
+      { status: 400 }
+    );
+  }
+
   const initResponse = await fetch(
     `${GEMINI_UPLOAD_URL}?uploadType=resumable&key=${GEMINI_API_KEY}`,
     {
@@ -36,7 +86,7 @@ export async function POST(request: NextRequest) {
       headers: {
         "X-Goog-Upload-Protocol": "resumable",
         "X-Goog-Upload-Command": "start",
-        "X-Goog-Upload-Header-Content-Length": String(fileBuffer.byteLength),
+        "X-Goog-Upload-Header-Content-Length": String(sizeBytes),
         "X-Goog-Upload-Header-Content-Type": mimeType,
         "Content-Type": "application/json",
       },
@@ -53,38 +103,117 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const uploadUrl = initResponse.headers.get("x-goog-upload-url");
-  if (!uploadUrl) {
+  const rawUploadUrl = initResponse.headers.get("x-goog-upload-url");
+  if (!rawUploadUrl) {
     return NextResponse.json(
       { error: "No upload URL returned by Gemini" },
       { status: 502 }
     );
   }
 
-  // Upload the file bytes
+  // Never hand the browser a URL that points somewhere unexpected or that carries
+  // credentials, even if Google's response format changes.
+  let uploadUrl: URL;
+  try {
+    uploadUrl = new URL(rawUploadUrl);
+  } catch {
+    return NextResponse.json(
+      { error: "Gemini returned a malformed upload URL" },
+      { status: 502 }
+    );
+  }
+
+  if (uploadUrl.protocol !== "https:" || uploadUrl.hostname !== GEMINI_UPLOAD_HOST) {
+    console.error("[gemini-upload] Unexpected upload host:", uploadUrl.hostname);
+    return NextResponse.json(
+      { error: "Gemini returned an unexpected upload host" },
+      { status: 502 }
+    );
+  }
+
+  for (const param of ["key", "apiKey", "api_key"]) {
+    if (uploadUrl.searchParams.has(param)) {
+      console.warn(
+        "[gemini-upload] Stripping unexpected credential param from upload URL:",
+        param
+      );
+      uploadUrl.searchParams.delete(param);
+    }
+  }
+
+  return NextResponse.json({
+    uploadUrl: uploadUrl.toString(),
+    mimeType,
+    displayName,
+  });
+}
+
+/**
+ * Streams the file through this function to Gemini and returns the finished file URI.
+ * Subject to Vercel's request-body cap, so it is only reachable as a fallback.
+ */
+async function proxyUpload(request: NextRequest): Promise<NextResponse> {
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json({ error: "Invalid form data" }, { status: 400 });
+  }
+
+  const file = formData.get("file") as File | null;
+  if (!file) {
+    return NextResponse.json({ error: "No file provided" }, { status: 400 });
+  }
+
+  const mimeType = file.type || "application/octet-stream";
+  const fileBuffer = await file.arrayBuffer();
+
+  const initResponse = await fetch(
+    `${GEMINI_UPLOAD_URL}?uploadType=resumable&key=${GEMINI_API_KEY}`,
+    {
+      method: "POST",
+      headers: {
+        "X-Goog-Upload-Protocol": "resumable",
+        "X-Goog-Upload-Command": "start",
+        "X-Goog-Upload-Header-Content-Length": String(fileBuffer.byteLength),
+        "X-Goog-Upload-Header-Content-Type": mimeType,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ file: { display_name: file.name } }),
+    }
+  );
+
+  const uploadUrl = initResponse.ok
+    ? initResponse.headers.get("x-goog-upload-url")
+    : null;
+
+  if (!uploadUrl) {
+    console.error("[gemini-upload] Fallback init failed:", await initResponse.text());
+    return NextResponse.json(
+      { error: "Failed to initiate Gemini upload" },
+      { status: 502 }
+    );
+  }
+
   const uploadResponse = await fetch(uploadUrl, {
     method: "POST",
     headers: {
       "X-Goog-Upload-Offset": "0",
       "X-Goog-Upload-Command": "upload, finalize",
-      "Content-Length": String(fileBuffer.byteLength),
       "Content-Type": mimeType,
     },
     body: fileBuffer,
   });
 
   if (!uploadResponse.ok) {
-    const errorText = await uploadResponse.text();
-    console.error("[gemini-upload] Upload failed:", errorText);
+    console.error("[gemini-upload] Fallback upload failed:", await uploadResponse.text());
     return NextResponse.json(
       { error: "Failed to upload file to Gemini" },
       { status: 502 }
     );
   }
 
-  const uploadResult = await uploadResponse.json();
-  const fileUri: string = uploadResult?.file?.uri;
-
+  const fileUri: string | undefined = (await uploadResponse.json())?.file?.uri;
   if (!fileUri) {
     return NextResponse.json(
       { error: "Gemini did not return a file URI" },
@@ -92,5 +221,5 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  return NextResponse.json({ fileUri, mimeType, displayName });
+  return NextResponse.json({ fileUri, mimeType, displayName: file.name });
 }

--- a/src/features/bulkTranslation/components/BatchProgressView.tsx
+++ b/src/features/bulkTranslation/components/BatchProgressView.tsx
@@ -1,0 +1,325 @@
+"use client";
+
+import { useState } from "react";
+import toast from "react-hot-toast";
+import {
+  AlertCircle,
+  CheckCircle2,
+  Clock,
+  Download,
+  FileText,
+  Loader2,
+  RotateCcw,
+  XCircle,
+} from "lucide-react";
+import { Button } from "@/features/ui/components/ui/button";
+import { ConfirmDialog } from "@/features/ui/components/ui/confirm-dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/features/ui/components/ui/select";
+import { useTranslatedSuffix } from "@/shared/utils/filenameUtils";
+import { cn } from "@/shared/lib/utils";
+import { Batch, BatchItem, BatchItemStatus } from "../types/types.Bulk";
+import {
+  BulkDownloadFormat,
+  BulkDownloadProgress,
+  downloadBatchAsZip,
+  PDF_SLOW_THRESHOLD,
+} from "../utils/downloadAll";
+import { cancelBatch, retryFailedItems } from "../services/batchService";
+
+interface BatchProgressViewProps {
+  batch: Batch;
+  projectName: string;
+  onChanged: () => void;
+}
+
+const FORMAT_LABELS: Record<BulkDownloadFormat, string> = {
+  docx: "Word (.docx)",
+  pdf: "PDF (.pdf)",
+  md: "Markdown (.md)",
+  txt: "Plain text (.txt)",
+};
+
+export function BatchProgressView({
+  batch,
+  projectName,
+  onChanged,
+}: BatchProgressViewProps) {
+  const [format, setFormat] = useState<BulkDownloadFormat>("docx");
+  const [downloading, setDownloading] = useState(false);
+  const [downloadProgress, setDownloadProgress] =
+    useState<BulkDownloadProgress | null>(null);
+  const [confirmCancel, setConfirmCancel] = useState(false);
+  const [confirmSlowPdf, setConfirmSlowPdf] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const translatedSuffix = useTranslatedSuffix();
+
+  const finished =
+    batch.status === "Completed" ||
+    batch.status === "CompletedWithErrors" ||
+    batch.status === "Cancelled";
+
+  const runDownload = async () => {
+    setConfirmSlowPdf(false);
+    setDownloading(true);
+    setDownloadProgress(null);
+
+    try {
+      const result = await downloadBatchAsZip(
+        batch.items,
+        format,
+        batch.name || projectName || "translations",
+        translatedSuffix,
+        setDownloadProgress
+      );
+
+      if (result.succeeded === 0) {
+        toast.error("Nothing could be downloaded. Please try again.");
+      } else if (result.failed.length > 0) {
+        // Partial success is reported explicitly — a zip quietly missing three documents
+        // is worse than one that says so.
+        toast.success(
+          `Downloaded ${result.succeeded} document${result.succeeded === 1 ? "" : "s"}. ${result.failed.length} could not be included — see _missing-documents.txt in the zip.`,
+          { duration: 6000 }
+        );
+      } else {
+        toast.success(
+          `Downloaded ${result.succeeded} translation${result.succeeded === 1 ? "" : "s"}.`
+        );
+      }
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to build the download"
+      );
+    } finally {
+      setDownloading(false);
+      setDownloadProgress(null);
+    }
+  };
+
+  const handleDownload = () => {
+    if (format === "pdf" && batch.completedCount > PDF_SLOW_THRESHOLD) {
+      setConfirmSlowPdf(true);
+      return;
+    }
+    runDownload();
+  };
+
+  const handleRetry = async () => {
+    setBusy(true);
+    try {
+      const result = await retryFailedItems(batch.id);
+      toast.success(
+        `Requeued ${result.requeuedCount} document${result.requeuedCount === 1 ? "" : "s"}.`
+      );
+      onChanged();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Retry failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleCancel = async () => {
+    setBusy(true);
+    try {
+      await cancelBatch(batch.id);
+      toast.success("Batch cancelled.");
+      onChanged();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Cancel failed");
+    } finally {
+      setBusy(false);
+      setConfirmCancel(false);
+    }
+  };
+
+  return (
+    <div className="space-y-5">
+      <div className="rounded-lg border border-border/70 p-4 space-y-3">
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <p className="text-sm font-medium truncate">
+              {batch.name || "Bulk translation"}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {batch.completedCount} of {batch.totalItems} done
+              {batch.failedCount > 0 && ` · ${batch.failedCount} failed`}
+              {batch.runningCount > 0 && ` · ${batch.runningCount} translating`}
+            </p>
+          </div>
+
+          {!finished && (
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={busy}
+              onClick={() => setConfirmCancel(true)}
+            >
+              Cancel
+            </Button>
+          )}
+        </div>
+
+        <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className={cn(
+              "h-full rounded-full transition-[width] duration-500",
+              batch.failedCount > 0
+                ? "bg-amber-500"
+                : "bg-suliko-default-color"
+            )}
+            style={{ width: `${batch.progressPercent}%` }}
+          />
+        </div>
+      </div>
+
+      <div className="divide-y divide-border/60 rounded-lg border border-border/70 overflow-hidden">
+        {batch.items.map((item) => (
+          <BatchItemRow key={item.id} item={item} />
+        ))}
+      </div>
+
+      {batch.completedCount > 0 && (
+        <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border/70 bg-muted/20 p-4">
+          <Select
+            value={format}
+            onValueChange={(value) => setFormat(value as BulkDownloadFormat)}
+          >
+            <SelectTrigger className="w-[180px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {(
+                Object.keys(FORMAT_LABELS) as BulkDownloadFormat[]
+              ).map((value) => (
+                <SelectItem key={value} value={value}>
+                  {FORMAT_LABELS[value]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Button onClick={handleDownload} disabled={downloading} className="gap-2">
+            {downloading ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Download className="h-4 w-4" />
+            )}
+            {downloading
+              ? downloadProgress
+                ? `Preparing ${downloadProgress.completed + 1} of ${downloadProgress.total}…`
+                : "Preparing…"
+              : `Download all (${batch.completedCount})`}
+          </Button>
+
+          {batch.failedCount > 0 && (
+            <Button
+              variant="outline"
+              onClick={handleRetry}
+              disabled={busy}
+              className="gap-2"
+            >
+              <RotateCcw className="h-4 w-4" />
+              Retry {batch.failedCount} failed
+            </Button>
+          )}
+        </div>
+      )}
+
+      {batch.completedCount === 0 && batch.failedCount > 0 && (
+        <Button
+          variant="outline"
+          onClick={handleRetry}
+          disabled={busy}
+          className="gap-2"
+        >
+          <RotateCcw className="h-4 w-4" />
+          Retry {batch.failedCount} failed
+        </Button>
+      )}
+
+      <ConfirmDialog
+        open={confirmCancel}
+        onOpenChange={setConfirmCancel}
+        title="Cancel this batch?"
+        description="Documents that have not started yet will be dropped. Anything already translating will finish, since it has already been charged."
+        confirmLabel="Cancel batch"
+        loading={busy}
+        onConfirm={handleCancel}
+      />
+
+      <ConfirmDialog
+        open={confirmSlowPdf}
+        onOpenChange={setConfirmSlowPdf}
+        title={`Build ${batch.completedCount} PDFs?`}
+        description="PDFs are rendered one at a time in your browser, so this can take several minutes and will keep this tab busy. Word or Markdown are much faster."
+        confirmLabel="Build PDFs"
+        onConfirm={runDownload}
+      />
+    </div>
+  );
+}
+
+const STATUS_META: Record<
+  BatchItemStatus,
+  { icon: typeof FileText; className: string; label: string }
+> = {
+  Pending: { icon: Clock, className: "text-muted-foreground", label: "Queued" },
+  Running: {
+    icon: Loader2,
+    className: "text-suliko-default-color",
+    label: "Translating",
+  },
+  Completed: {
+    icon: CheckCircle2,
+    className: "text-green-600 dark:text-green-400",
+    label: "Done",
+  },
+  Failed: {
+    icon: AlertCircle,
+    className: "text-red-600 dark:text-red-400",
+    label: "Failed",
+  },
+  Cancelled: { icon: XCircle, className: "text-muted-foreground", label: "Cancelled" },
+};
+
+function BatchItemRow({ item }: { item: BatchItem }) {
+  const meta = STATUS_META[item.status];
+  const Icon = meta.icon;
+
+  const folder = item.relativePath?.includes("/")
+    ? item.relativePath.slice(0, item.relativePath.lastIndexOf("/"))
+    : null;
+
+  return (
+    <div className="flex items-center gap-3 px-4 py-2.5">
+      <Icon
+        className={cn(
+          "h-4 w-4 shrink-0",
+          meta.className,
+          item.status === "Running" && "animate-spin"
+        )}
+      />
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm">{item.fileName}</p>
+        {folder && (
+          <p className="truncate text-xs text-muted-foreground">{folder}/</p>
+        )}
+        {item.status === "Failed" && item.errorMessage && (
+          <p className="mt-0.5 text-xs text-red-600 dark:text-red-400">
+            {item.errorMessage}
+          </p>
+        )}
+      </div>
+
+      <span className={cn("shrink-0 text-xs", meta.className)}>{meta.label}</span>
+    </div>
+  );
+}

--- a/src/features/bulkTranslation/components/BulkApplyPanel.tsx
+++ b/src/features/bulkTranslation/components/BulkApplyPanel.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Wand2 } from "lucide-react";
+import LanguageSelect from "@/features/translation/components/LanguageSelect";
+import { Button } from "@/features/ui/components/ui/button";
+import { Textarea } from "@/features/ui/components/ui/textarea";
+import { NameTranslationItem } from "@/features/translation/types/types.Translation";
+import { DocumentSettings } from "../types/types.Bulk";
+import { NameGlossaryEditor } from "./NameGlossaryEditor";
+
+interface BulkApplyPanelProps {
+  selectedCount: number;
+  onApply: (patch: Partial<DocumentSettings>) => void;
+  disabled?: boolean;
+}
+
+/**
+ * Applies one setting across every selected document.
+ *
+ * Each field applies on its own. Editing a folder of fifty documents one row at a time is
+ * the thing this feature exists to avoid, but a panel that wrote all its fields at once
+ * would clobber per-document notes the user had already written, so nothing is written
+ * unless its own Apply is pressed.
+ */
+export function BulkApplyPanel({
+  selectedCount,
+  onApply,
+  disabled,
+}: BulkApplyPanelProps) {
+  const [targetLanguageId, setTargetLanguageId] = useState<number>(0);
+  const [sourceLanguageId, setSourceLanguageId] = useState<number>(0);
+  const [instructions, setInstructions] = useState("");
+  const [names, setNames] = useState<NameTranslationItem[]>([]);
+  const [justApplied, setJustApplied] = useState<string | null>(null);
+
+  const apply = (field: string, patch: Partial<DocumentSettings>) => {
+    onApply(patch);
+    setJustApplied(field);
+    window.setTimeout(() => setJustApplied(null), 1500);
+  };
+
+  const label = `${selectedCount} document${selectedCount === 1 ? "" : "s"}`;
+
+  return (
+    <div className="space-y-4 rounded-lg border border-suliko-default-color/30 bg-suliko-default-color/5 p-4">
+      <div className="flex items-center gap-2">
+        <Wand2 className="h-4 w-4 text-suliko-default-color" />
+        <p className="text-sm font-medium">Apply to {label}</p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-muted-foreground">
+            Translate from
+          </label>
+          <div className="flex gap-2">
+            <div className="flex-1">
+              <LanguageSelect
+                value={sourceLanguageId}
+                onChange={setSourceLanguageId}
+                detectOption="Detect automatically"
+              />
+            </div>
+            <ApplyButton
+              applied={justApplied === "source"}
+              disabled={disabled}
+              onClick={() => apply("source", { sourceLanguageId })}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-muted-foreground">
+            Translate into
+          </label>
+          <div className="flex gap-2">
+            <div className="flex-1">
+              <LanguageSelect
+                value={targetLanguageId}
+                onChange={setTargetLanguageId}
+              />
+            </div>
+            <ApplyButton
+              applied={justApplied === "target"}
+              // Language id 0 means "detect", which is not a valid destination.
+              disabled={disabled || targetLanguageId === 0}
+              onClick={() => apply("target", { targetLanguageId })}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <label className="text-xs font-medium text-muted-foreground">
+          Notes and instructions
+        </label>
+        <Textarea
+          value={instructions}
+          onChange={(e) => setInstructions(e.target.value)}
+          placeholder="e.g. keep company names in English, use formal register"
+          rows={2}
+          className="text-sm"
+        />
+        <div className="flex justify-end">
+          <ApplyButton
+            applied={justApplied === "instructions"}
+            disabled={disabled}
+            onClick={() => apply("instructions", { instructions })}
+            wide
+          />
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <label className="text-xs font-medium text-muted-foreground">
+          Name spellings
+        </label>
+        <NameGlossaryEditor names={names} onChange={setNames} />
+        <div className="flex justify-end">
+          <ApplyButton
+            applied={justApplied === "names"}
+            disabled={disabled || names.length === 0}
+            onClick={() =>
+              apply("names", {
+                // Blank rows are an artefact of the editor's "add" button, not something
+                // the user meant to send.
+                nameTranslations: names.filter((n) => n.original.trim()),
+              })
+            }
+            wide
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ApplyButton({
+  applied,
+  disabled,
+  onClick,
+  wide,
+}: {
+  applied: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+  wide?: boolean;
+}) {
+  return (
+    <Button
+      type="button"
+      variant={applied ? "default" : "outline"}
+      size="sm"
+      disabled={disabled}
+      onClick={onClick}
+      className={wide ? "gap-1.5" : "shrink-0 gap-1.5"}
+    >
+      {applied ? (
+        <>
+          <Check className="h-3.5 w-3.5" />
+          Applied
+        </>
+      ) : (
+        "Apply"
+      )}
+    </Button>
+  );
+}

--- a/src/features/bulkTranslation/components/BulkDocumentTable.tsx
+++ b/src/features/bulkTranslation/components/BulkDocumentTable.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useState } from "react";
+import {
+  AlertCircle,
+  ChevronDown,
+  ChevronRight,
+  FileText,
+  Loader2,
+  Trash2,
+} from "lucide-react";
+import LanguageSelect from "@/features/translation/components/LanguageSelect";
+import { Button } from "@/features/ui/components/ui/button";
+import { Checkbox } from "@/features/ui/components/ui/checkbox";
+import { Textarea } from "@/features/ui/components/ui/textarea";
+import { cn } from "@/shared/lib/utils";
+import { DocumentSettings, StagedDocument } from "../types/types.Bulk";
+import { formatFileSize } from "../utils/folderScanning";
+import { NameGlossaryEditor } from "./NameGlossaryEditor";
+
+interface BulkDocumentTableProps {
+  documents: StagedDocument[];
+  selectedIds: Set<string>;
+  onToggleSelected: (id: string) => void;
+  onToggleAll: () => void;
+  onUpdateSettings: (id: string, patch: Partial<DocumentSettings>) => void;
+  onRemove: (id: string) => void;
+  disabled?: boolean;
+}
+
+export function BulkDocumentTable({
+  documents,
+  selectedIds,
+  onToggleSelected,
+  onToggleAll,
+  onUpdateSettings,
+  onRemove,
+  disabled,
+}: BulkDocumentTableProps) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const allSelected =
+    documents.length > 0 && selectedIds.size === documents.length;
+  // Distinguished from "all" so the header checkbox can show an indeterminate state
+  // rather than implying a partial selection is a full one.
+  const someSelected = selectedIds.size > 0 && !allSelected;
+
+  return (
+    <div className="rounded-lg border border-border/70 overflow-hidden">
+      <div className="flex items-center gap-3 border-b bg-muted/40 px-4 py-2.5">
+        <Checkbox
+          // Radix takes "indeterminate" as a checked value; a partial selection must not
+          // render as fully checked, or "select all" appears to be a no-op.
+          checked={someSelected ? "indeterminate" : allSelected}
+          onCheckedChange={onToggleAll}
+          disabled={disabled}
+          aria-label="Select all documents"
+        />
+        <span className="text-xs font-medium text-muted-foreground">
+          {selectedIds.size > 0
+            ? `${selectedIds.size} of ${documents.length} selected`
+            : `${documents.length} document${documents.length === 1 ? "" : "s"}`}
+        </span>
+      </div>
+
+      <div className="divide-y divide-border/60">
+        {documents.map((doc) => (
+          <DocumentRow
+            key={doc.id}
+            document={doc}
+            selected={selectedIds.has(doc.id)}
+            expanded={expandedId === doc.id}
+            onToggleSelected={() => onToggleSelected(doc.id)}
+            onToggleExpanded={() =>
+              setExpandedId((prev) => (prev === doc.id ? null : doc.id))
+            }
+            onUpdateSettings={(patch) => onUpdateSettings(doc.id, patch)}
+            onRemove={() => onRemove(doc.id)}
+            disabled={disabled}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface DocumentRowProps {
+  document: StagedDocument;
+  selected: boolean;
+  expanded: boolean;
+  onToggleSelected: () => void;
+  onToggleExpanded: () => void;
+  onUpdateSettings: (patch: Partial<DocumentSettings>) => void;
+  onRemove: () => void;
+  disabled?: boolean;
+}
+
+function DocumentRow({
+  document: doc,
+  selected,
+  expanded,
+  onToggleSelected,
+  onToggleExpanded,
+  onUpdateSettings,
+  onRemove,
+  disabled,
+}: DocumentRowProps) {
+  // The folder path is what distinguishes two files with the same name in different
+  // subfolders, so it is shown whenever it adds information beyond the name alone.
+  const folder = doc.relativePath.includes("/")
+    ? doc.relativePath.slice(0, doc.relativePath.lastIndexOf("/"))
+    : null;
+
+  const hasInstructions = doc.settings.instructions.trim().length > 0;
+  const nameCount = doc.settings.nameTranslations.filter((n) => n.original.trim()).length;
+
+  return (
+    <div className={cn(selected && "bg-suliko-default-color/5")}>
+      <div className="flex items-center gap-3 px-4 py-3">
+        <Checkbox
+          checked={selected}
+          onCheckedChange={onToggleSelected}
+          disabled={disabled}
+          aria-label={`Select ${doc.file.name}`}
+        />
+
+        <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+
+        <button
+          type="button"
+          onClick={onToggleExpanded}
+          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+        >
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium">{doc.file.name}</p>
+            <p className="truncate text-xs text-muted-foreground">
+              {folder && <span className="mr-2">{folder}/</span>}
+              {formatFileSize(doc.file.size)}
+              {doc.pageCount !== null && (
+                <span className="ml-2">
+                  · {doc.pageCount} page{doc.pageCount === 1 ? "" : "s"}
+                </span>
+              )}
+              {hasInstructions && <span className="ml-2">· has notes</span>}
+              {nameCount > 0 && <span className="ml-2">· {nameCount} names</span>}
+            </p>
+          </div>
+
+          <UploadIndicator document={doc} />
+
+          {expanded ? (
+            <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+          )}
+        </button>
+
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-8 w-8 shrink-0 p-0"
+          onClick={onRemove}
+          disabled={disabled}
+          aria-label={`Remove ${doc.file.name}`}
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+
+      {expanded && (
+        <div className="space-y-4 border-t border-border/50 bg-muted/20 px-4 py-4">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-muted-foreground">
+                Translate from
+              </label>
+              <LanguageSelect
+                value={doc.settings.sourceLanguageId}
+                onChange={(value) => onUpdateSettings({ sourceLanguageId: value })}
+                detectOption="Detect automatically"
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-muted-foreground">
+                Translate into
+              </label>
+              <LanguageSelect
+                value={doc.settings.targetLanguageId}
+                onChange={(value) => onUpdateSettings({ targetLanguageId: value })}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-muted-foreground">
+              Notes and instructions
+            </label>
+            <Textarea
+              value={doc.settings.instructions}
+              onChange={(e) => onUpdateSettings({ instructions: e.target.value })}
+              placeholder="e.g. keep company names in English, use formal register"
+              rows={3}
+              className="text-sm"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-muted-foreground">
+              Name spellings
+            </label>
+            <NameGlossaryEditor
+              names={doc.settings.nameTranslations}
+              onChange={(names) => onUpdateSettings({ nameTranslations: names })}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function UploadIndicator({ document: doc }: { document: StagedDocument }) {
+  if (doc.upload.status === "uploading") {
+    return (
+      <span className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        {Math.round(doc.upload.progress * 100)}%
+      </span>
+    );
+  }
+
+  if (doc.upload.status === "error") {
+    return (
+      <span
+        className="flex shrink-0 items-center gap-1.5 text-xs text-red-600 dark:text-red-400"
+        title={doc.upload.error}
+      >
+        <AlertCircle className="h-3.5 w-3.5" />
+        Failed
+      </span>
+    );
+  }
+
+  return null;
+}

--- a/src/features/bulkTranslation/components/BulkTranslationPanel.tsx
+++ b/src/features/bulkTranslation/components/BulkTranslationPanel.tsx
@@ -1,0 +1,440 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import toast from "react-hot-toast";
+import { AlertTriangle, Loader2, Play } from "lucide-react";
+import { Button } from "@/features/ui/components/ui/button";
+import { getProjectNames } from "@/features/projects";
+import { uploadFileToGemini } from "@/features/translation/services/geminiUploadService";
+import { DEFAULT_DOCUMENT_OUTPUT_FORMAT } from "@/features/translation/types/types.Translation";
+import { NameTranslationItem } from "@/features/translation/types/types.Translation";
+import {
+  Batch,
+  CreateBatchItemRequest,
+  DocumentSettings,
+  StagedDocument,
+} from "../types/types.Bulk";
+import {
+  FolderScanResult,
+  RejectionReason,
+  resolveMimeType,
+} from "../utils/folderScanning";
+import { countPagesForFile } from "../utils/pageCounting";
+import {
+  PAGE_COUNT_CONCURRENCY,
+  runWithConcurrency,
+  UPLOAD_CONCURRENCY,
+} from "../utils/uploadPool";
+import { createBatch, getBatch } from "../services/batchService";
+import { FolderDropZone } from "./FolderDropZone";
+import { BulkDocumentTable } from "./BulkDocumentTable";
+import { BulkApplyPanel } from "./BulkApplyPanel";
+import { BatchProgressView } from "./BatchProgressView";
+
+interface BulkTranslationPanelProps {
+  projectId: string;
+  projectName: string;
+}
+
+const REJECTION_LABELS: Record<RejectionReason, string> = {
+  unsupported: "unsupported file type",
+  subtitles: "subtitle files need the dedicated SRT translator",
+  "too-large": "larger than 50MB",
+  empty: "empty file",
+};
+
+/** Gemini's default; the model is not exposed per document, only the language pair is. */
+const DEFAULT_MODEL = 2;
+
+const defaultSettings = (
+  glossary: NameTranslationItem[]
+): DocumentSettings => ({
+  targetLanguageId: 0,
+  sourceLanguageId: 0,
+  outputFormat: DEFAULT_DOCUMENT_OUTPUT_FORMAT,
+  model: DEFAULT_MODEL,
+  instructions: "",
+  nameTranslations: glossary,
+});
+
+export function BulkTranslationPanel({
+  projectId,
+  projectName,
+}: BulkTranslationPanelProps) {
+  const [documents, setDocuments] = useState<StagedDocument[]>([]);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [rejected, setRejected] = useState<FolderScanResult["rejected"]>([]);
+  const [glossary, setGlossary] = useState<NameTranslationItem[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [batch, setBatch] = useState<Batch | null>(null);
+
+  // Seed every document from the project's saved glossary so names stay consistent with
+  // translations already filed in this project, without the user re-entering them.
+  useEffect(() => {
+    getProjectNames(projectId)
+      .then((names) =>
+        setGlossary(
+          names.map(({ original, translation, type }) => ({
+            original,
+            translation,
+            type,
+          }))
+        )
+      )
+      .catch(() => setGlossary([]));
+  }, [projectId]);
+
+  const handleFilesSelected = (result: FolderScanResult) => {
+    setRejected(result.rejected);
+
+    if (result.accepted.length === 0) {
+      if (result.rejected.length > 0) {
+        toast.error("None of those files can be translated.");
+      }
+      return;
+    }
+
+    const staged: StagedDocument[] = result.accepted.map((entry, index) => ({
+      id: `${Date.now()}-${index}-${entry.relativePath}`,
+      file: entry.file,
+      relativePath: entry.relativePath,
+      pageCount: null,
+      settings: defaultSettings(glossary),
+      upload: { status: "idle", progress: 0 },
+    }));
+
+    setDocuments(staged);
+    setSelectedIds(new Set());
+    void resolvePageCounts(staged);
+  };
+
+  /**
+   * Page counts drive both the price and the time estimate. Resolved in the background so
+   * the list appears immediately rather than after every file has been inspected.
+   */
+  const resolvePageCounts = useCallback(async (staged: StagedDocument[]) => {
+    await runWithConcurrency(staged, PAGE_COUNT_CONCURRENCY, async (doc) => {
+      const pageCount = await countPagesForFile(doc.file);
+      setDocuments((prev) =>
+        prev.map((d) => (d.id === doc.id ? { ...d, pageCount } : d))
+      );
+    });
+  }, []);
+
+  const toggleSelected = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    setSelectedIds((prev) =>
+      prev.size === documents.length
+        ? new Set()
+        : new Set(documents.map((d) => d.id))
+    );
+  };
+
+  const updateSettings = (id: string, patch: Partial<DocumentSettings>) => {
+    setDocuments((prev) =>
+      prev.map((doc) =>
+        doc.id === id ? { ...doc, settings: { ...doc.settings, ...patch } } : doc
+      )
+    );
+  };
+
+  const applyToSelected = (patch: Partial<DocumentSettings>) => {
+    setDocuments((prev) =>
+      prev.map((doc) =>
+        selectedIds.has(doc.id)
+          ? { ...doc, settings: { ...doc.settings, ...patch } }
+          : doc
+      )
+    );
+  };
+
+  const removeDocument = (id: string) => {
+    setDocuments((prev) => prev.filter((doc) => doc.id !== id));
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+  };
+
+  const missingTargetLanguage = documents.filter(
+    (doc) => doc.settings.targetLanguageId === 0
+  );
+
+  const handleSubmit = async () => {
+    if (missingTargetLanguage.length > 0) {
+      toast.error(
+        `${missingTargetLanguage.length} document${missingTargetLanguage.length === 1 ? " still needs" : "s still need"} a target language.`
+      );
+      return;
+    }
+
+    setSubmitting(true);
+
+    try {
+      // Upload first, then queue. The backend only ever receives file URIs, so a batch can
+      // never be created referencing bytes that failed to reach Google.
+      const uploaded = await uploadAll();
+      const usable = uploaded.filter((doc) => doc.upload.fileUri);
+
+      if (usable.length === 0) {
+        toast.error("No files could be uploaded. Please try again.");
+        return;
+      }
+
+      if (usable.length < uploaded.length) {
+        toast.error(
+          `${uploaded.length - usable.length} file${uploaded.length - usable.length === 1 ? "" : "s"} could not be uploaded and will be skipped.`,
+          { duration: 5000 }
+        );
+      }
+
+      const items: CreateBatchItemRequest[] = usable.map((doc) => ({
+        fileName: doc.file.name,
+        relativePath: doc.relativePath,
+        fileUri: doc.upload.fileUri!,
+        mimeType: doc.upload.mimeType || resolveMimeType(doc.file),
+        pageCount: doc.pageCount ?? 1,
+        targetLanguageId: doc.settings.targetLanguageId,
+        outputLanguageId: doc.settings.targetLanguageId,
+        // 0 is the UI's "detect automatically"; the API expects null for that.
+        sourceLanguageId:
+          doc.settings.sourceLanguageId === 0
+            ? null
+            : doc.settings.sourceLanguageId,
+        outputFormat: doc.settings.outputFormat,
+        model: doc.settings.model,
+        instructions: doc.settings.instructions.trim() || null,
+        nameTranslations: doc.settings.nameTranslations.filter((n) =>
+          n.original.trim()
+        ),
+      }));
+
+      const response = await createBatch({
+        projectId,
+        name: deriveBatchName(usable),
+        items,
+      });
+
+      setBatch(response.data);
+      setDocuments([]);
+      setSelectedIds(new Set());
+      toast.success(`Queued ${items.length} documents for translation.`);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Could not queue the batch"
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  /**
+   * Uploads every staged file straight to Google, a few at a time, updating each row's
+   * progress as it goes. Returns the documents with their upload state resolved.
+   */
+  const uploadAll = async (): Promise<StagedDocument[]> => {
+    const current = documents;
+
+    setDocuments((prev) =>
+      prev.map((doc) => ({
+        ...doc,
+        upload: { status: "uploading", progress: 0 },
+      }))
+    );
+
+    return runWithConcurrency(current, UPLOAD_CONCURRENCY, async (doc) => {
+      try {
+        const result = await uploadFileToGemini(doc.file, {
+          onProgress: (fraction) =>
+            setDocuments((prev) =>
+              prev.map((d) =>
+                d.id === doc.id
+                  ? { ...d, upload: { ...d.upload, progress: fraction } }
+                  : d
+              )
+            ),
+        });
+
+        const upload: StagedDocument["upload"] = {
+          status: "uploaded",
+          progress: 1,
+          fileUri: result.fileUri,
+          mimeType: result.mimeType,
+        };
+
+        setDocuments((prev) =>
+          prev.map((d) => (d.id === doc.id ? { ...d, upload } : d))
+        );
+
+        return { ...doc, upload };
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Upload failed";
+
+        const upload: StagedDocument["upload"] = {
+          status: "error",
+          progress: 0,
+          error: message,
+        };
+
+        setDocuments((prev) =>
+          prev.map((d) => (d.id === doc.id ? { ...d, upload } : d))
+        );
+
+        // One bad file must not abort the folder; it is reported and skipped.
+        return { ...doc, upload };
+      }
+    });
+  };
+
+  const refreshBatch = useCallback(async () => {
+    if (!batch) return;
+    try {
+      const response = await getBatch(batch.id);
+      setBatch(response.data);
+    } catch {
+      // Transient polling failures are not worth interrupting the user over.
+    }
+  }, [batch]);
+
+  useBatchPolling(batch, refreshBatch);
+
+  if (batch) {
+    return (
+      <div className="space-y-5">
+        <BatchProgressView
+          batch={batch}
+          projectName={projectName}
+          onChanged={refreshBatch}
+        />
+        <Button variant="outline" onClick={() => setBatch(null)}>
+          Translate another folder
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      {documents.length === 0 && (
+        <FolderDropZone onFilesSelected={handleFilesSelected} disabled={submitting} />
+      )}
+
+      {rejected.length > 0 && (
+        <div className="flex gap-3 rounded-lg border border-amber-300/60 bg-amber-50 p-3 text-xs dark:border-amber-800/50 dark:bg-amber-950/30">
+          <AlertTriangle className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+          <div className="space-y-1">
+            <p className="font-medium text-amber-800 dark:text-amber-300">
+              {rejected.length} file{rejected.length === 1 ? "" : "s"} skipped
+            </p>
+            <ul className="space-y-0.5 text-amber-700 dark:text-amber-400">
+              {rejected.slice(0, 5).map((file) => (
+                <li key={file.relativePath}>
+                  {file.name} — {REJECTION_LABELS[file.reason]}
+                </li>
+              ))}
+              {rejected.length > 5 && <li>…and {rejected.length - 5} more</li>}
+            </ul>
+          </div>
+        </div>
+      )}
+
+      {documents.length > 0 && (
+        <>
+          {selectedIds.size > 0 && (
+            <BulkApplyPanel
+              selectedCount={selectedIds.size}
+              onApply={applyToSelected}
+              disabled={submitting}
+            />
+          )}
+
+          <BulkDocumentTable
+            documents={documents}
+            selectedIds={selectedIds}
+            onToggleSelected={toggleSelected}
+            onToggleAll={toggleAll}
+            onUpdateSettings={updateSettings}
+            onRemove={removeDocument}
+            disabled={submitting}
+          />
+
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <p className="text-xs text-muted-foreground">
+              {missingTargetLanguage.length > 0
+                ? `${missingTargetLanguage.length} document${missingTargetLanguage.length === 1 ? "" : "s"} still need a target language.`
+                : `${documents.length} document${documents.length === 1 ? "" : "s"} ready · ${totalPages(documents)} pages total`}
+            </p>
+
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setDocuments([]);
+                  setSelectedIds(new Set());
+                  setRejected([]);
+                }}
+                disabled={submitting}
+              >
+                Clear
+              </Button>
+              <Button
+                onClick={handleSubmit}
+                disabled={submitting || missingTargetLanguage.length > 0}
+                className="gap-2"
+              >
+                {submitting ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Play className="h-4 w-4" />
+                )}
+                {submitting ? "Uploading…" : `Translate ${documents.length}`}
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+const totalPages = (documents: StagedDocument[]) =>
+  documents.reduce((sum, doc) => sum + (doc.pageCount ?? 0), 0);
+
+/** Names the batch after the folder the documents came from, when there is one. */
+const deriveBatchName = (documents: StagedDocument[]): string | null => {
+  const first = documents[0]?.relativePath ?? "";
+  const root = first.includes("/") ? first.split("/")[0] : null;
+  return root;
+};
+
+/**
+ * Polls while work is outstanding and stops once the batch settles, so a finished batch
+ * left open in a tab does not keep hitting the API indefinitely.
+ */
+function useBatchPolling(batch: Batch | null, refresh: () => void) {
+  const refreshRef = useRef(refresh);
+  refreshRef.current = refresh;
+
+  const active =
+    !!batch &&
+    batch.status !== "Completed" &&
+    batch.status !== "CompletedWithErrors" &&
+    batch.status !== "Cancelled";
+
+  useEffect(() => {
+    if (!active) return;
+
+    const id = window.setInterval(() => refreshRef.current(), 4000);
+    return () => window.clearInterval(id);
+  }, [active]);
+}

--- a/src/features/bulkTranslation/components/FolderDropZone.tsx
+++ b/src/features/bulkTranslation/components/FolderDropZone.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { FolderUp, Loader2 } from "lucide-react";
+import { Button } from "@/features/ui/components/ui/button";
+import { cn } from "@/shared/lib/utils";
+import {
+  FolderScanResult,
+  scanDataTransfer,
+  scanFileList,
+} from "../utils/folderScanning";
+
+interface FolderDropZoneProps {
+  onFilesSelected: (result: FolderScanResult) => void;
+  disabled?: boolean;
+}
+
+/**
+ * Accepts a whole folder, by drag-drop or by picking one.
+ *
+ * Both routes are offered because they behave differently: the picker is reliable
+ * everywhere but shows an OS dialog, while drag-drop is faster and is what people reach
+ * for first when they already have the folder open.
+ */
+export function FolderDropZone({ onFilesSelected, disabled }: FolderDropZoneProps) {
+  const [isDragging, setIsDragging] = useState(false);
+  const [scanning, setScanning] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Drag events fire for every child element, so a plain boolean flickers as the pointer
+  // moves across the zone's contents. Counting enter/leave pairs tracks it correctly.
+  const dragDepth = useRef(0);
+
+  const handleDrop = async (event: React.DragEvent) => {
+    event.preventDefault();
+    dragDepth.current = 0;
+    setIsDragging(false);
+
+    if (disabled) return;
+
+    setScanning(true);
+    try {
+      const result = await scanDataTransfer(event.dataTransfer);
+      onFilesSelected(result);
+    } finally {
+      setScanning(false);
+    }
+  };
+
+  const handlePicked = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { files } = event.target;
+    if (!files || files.length === 0) return;
+
+    onFilesSelected(scanFileList(files));
+    // Reset so picking the same folder twice in a row still fires a change event.
+    event.target.value = "";
+  };
+
+  return (
+    <div
+      onDragEnter={(e) => {
+        e.preventDefault();
+        dragDepth.current += 1;
+        if (!disabled) setIsDragging(true);
+      }}
+      onDragLeave={(e) => {
+        e.preventDefault();
+        dragDepth.current -= 1;
+        if (dragDepth.current <= 0) setIsDragging(false);
+      }}
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={handleDrop}
+      className={cn(
+        "rounded-xl border-2 border-dashed p-10 text-center transition-colors",
+        isDragging
+          ? "border-suliko-default-color bg-suliko-default-color/5"
+          : "border-border/70 bg-muted/20",
+        disabled && "opacity-60 pointer-events-none"
+      )}
+    >
+      <div className="flex flex-col items-center gap-3">
+        <div className="rounded-full bg-background p-3 shadow-sm">
+          {scanning ? (
+            <Loader2 className="h-6 w-6 animate-spin text-suliko-default-color" />
+          ) : (
+            <FolderUp className="h-6 w-6 text-muted-foreground" />
+          )}
+        </div>
+
+        <div className="space-y-1">
+          <p className="text-sm font-medium">
+            {scanning ? "Reading folder…" : "Drop a folder here"}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            PDF, Word, text and image files are picked up. Subfolders are kept.
+          </p>
+        </div>
+
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled || scanning}
+          onClick={() => inputRef.current?.click()}
+        >
+          Choose folder
+        </Button>
+      </div>
+
+      <input
+        ref={inputRef}
+        type="file"
+        multiple
+        // Non-standard but supported everywhere that matters; React needs them lowercase.
+        {...{ webkitdirectory: "", directory: "" }}
+        className="hidden"
+        onChange={handlePicked}
+      />
+    </div>
+  );
+}

--- a/src/features/bulkTranslation/components/NameGlossaryEditor.tsx
+++ b/src/features/bulkTranslation/components/NameGlossaryEditor.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { Plus, X } from "lucide-react";
+import { Button } from "@/features/ui/components/ui/button";
+import { Input } from "@/features/ui/components/ui/input";
+import { NameTranslationItem } from "@/features/translation/types/types.Translation";
+
+interface NameGlossaryEditorProps {
+  names: NameTranslationItem[];
+  onChange: (names: NameTranslationItem[]) => void;
+}
+
+/**
+ * Editor for how proper names should be spelled in the output.
+ *
+ * Names are the thing translation models are least consistent about — the same person can
+ * come back spelled three ways across a folder of documents. Pinning them here makes the
+ * whole batch agree.
+ */
+export function NameGlossaryEditor({ names, onChange }: NameGlossaryEditorProps) {
+  const update = (index: number, patch: Partial<NameTranslationItem>) => {
+    onChange(names.map((name, i) => (i === index ? { ...name, ...patch } : name)));
+  };
+
+  const remove = (index: number) => {
+    onChange(names.filter((_, i) => i !== index));
+  };
+
+  const add = () => {
+    onChange([...names, { original: "", translation: "", type: "Person" }]);
+  };
+
+  return (
+    <div className="space-y-2">
+      {names.length === 0 && (
+        <p className="text-xs text-muted-foreground">
+          No fixed spellings yet. Add one to force a name to render a specific way.
+        </p>
+      )}
+
+      {names.map((name, index) => (
+        <div key={index} className="flex items-center gap-2">
+          <Input
+            value={name.original}
+            onChange={(e) => update(index, { original: e.target.value })}
+            placeholder="As written in the document"
+            className="h-8 text-xs"
+          />
+          <span className="text-xs text-muted-foreground shrink-0">→</span>
+          <Input
+            value={name.translation}
+            onChange={(e) => update(index, { translation: e.target.value })}
+            placeholder="Preferred spelling"
+            className="h-8 text-xs"
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0 shrink-0"
+            onClick={() => remove(index)}
+            aria-label={`Remove ${name.original || "name"}`}
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      ))}
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={add}
+        className="h-7 gap-1.5 text-xs"
+      >
+        <Plus className="h-3.5 w-3.5" />
+        Add name
+      </Button>
+    </div>
+  );
+}

--- a/src/features/bulkTranslation/index.ts
+++ b/src/features/bulkTranslation/index.ts
@@ -1,0 +1,5 @@
+export * from "./services/batchService";
+export * from "./types/types.Bulk";
+export * from "./utils/folderScanning";
+export * from "./utils/downloadAll";
+export { BulkTranslationPanel } from "./components/BulkTranslationPanel";

--- a/src/features/bulkTranslation/services/batchService.ts
+++ b/src/features/bulkTranslation/services/batchService.ts
@@ -1,0 +1,122 @@
+import { reaccessToken, useAuthStore } from "@/features/auth";
+import { API_BASE_URL } from "@/shared/constants/api";
+import {
+  BatchListResponse,
+  BatchResponse,
+  CreateBatchRequest,
+} from "../types/types.Bulk";
+
+/**
+ * Authenticated fetch with one transparent token refresh, matching the pattern used by
+ * projectService so batch calls behave identically on an expired session.
+ */
+const fetchWithAuth = async (
+  endpoint: string,
+  options: RequestInit = {}
+): Promise<Response> => {
+  const { token, refreshToken, setToken, setRefreshToken, reset } =
+    useAuthStore.getState();
+
+  if (!token) throw new Error("No token found");
+
+  const headers = new Headers(options.headers || {});
+  headers.set("Authorization", `Bearer ${token}`);
+
+  let response = await fetch(`${API_BASE_URL}${endpoint}`, {
+    ...options,
+    headers,
+    cache: "no-store",
+  });
+
+  if (response.status === 401 && refreshToken) {
+    try {
+      const newTokens = (await reaccessToken(refreshToken)) as {
+        token: string;
+        refreshToken: string;
+      };
+
+      setToken(newTokens.token);
+      setRefreshToken(newTokens.refreshToken);
+      headers.set("Authorization", `Bearer ${newTokens.token}`);
+
+      response = await fetch(`${API_BASE_URL}${endpoint}`, {
+        ...options,
+        headers,
+        cache: "no-store",
+      });
+    } catch {
+      reset();
+      throw new Error("Token refresh failed");
+    }
+  }
+
+  return response;
+};
+
+const readError = async (response: Response, fallback: string) => {
+  const body = await response.json().catch(() => ({}));
+  return new Error(body.message || fallback);
+};
+
+/**
+ * Queues a folder of documents. Returns as soon as the batch is persisted — translation
+ * happens in the backend worker pool, so this does not wait for any document to finish.
+ */
+export const createBatch = async (
+  request: CreateBatchRequest
+): Promise<BatchResponse> => {
+  const response = await fetchWithAuth("/batches", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) throw await readError(response, "Failed to queue the batch");
+
+  return response.json();
+};
+
+/** Current status of a batch, including every document's individual state. */
+export const getBatch = async (batchId: string): Promise<BatchResponse> => {
+  const response = await fetchWithAuth(`/batches/${batchId}`);
+
+  if (!response.ok) throw await readError(response, "Failed to load the batch");
+
+  return response.json();
+};
+
+export const getProjectBatches = async (
+  projectId: string
+): Promise<BatchListResponse> => {
+  const response = await fetchWithAuth(`/batches?projectId=${projectId}`);
+
+  if (!response.ok) throw await readError(response, "Failed to load batches");
+
+  return response.json();
+};
+
+/** Drops queued documents. Documents already translating are left to finish. */
+export const cancelBatch = async (
+  batchId: string
+): Promise<{ success: boolean; message: string }> => {
+  const response = await fetchWithAuth(`/batches/${batchId}/cancel`, {
+    method: "POST",
+  });
+
+  if (!response.ok) throw await readError(response, "Failed to cancel the batch");
+
+  return response.json();
+};
+
+/** Requeues only the documents that failed, each with a fresh attempt budget. */
+export const retryFailedItems = async (
+  batchId: string
+): Promise<{ success: boolean; requeuedCount: number }> => {
+  const response = await fetchWithAuth(`/batches/${batchId}/retry-failed`, {
+    method: "POST",
+  });
+
+  if (!response.ok) throw await readError(response, "Failed to retry the batch");
+
+  return response.json();
+};

--- a/src/features/bulkTranslation/types/types.Bulk.ts
+++ b/src/features/bulkTranslation/types/types.Bulk.ts
@@ -1,0 +1,122 @@
+import { NameTranslationItem } from "@/features/translation/types/types.Translation";
+
+/** Mirrors the backend BatchItemStatus constants. */
+export type BatchItemStatus =
+  | "Pending"
+  | "Running"
+  | "Completed"
+  | "Failed"
+  | "Cancelled";
+
+/** Mirrors the backend BatchStatus constants. */
+export type BatchStatus =
+  | "Queued"
+  | "Running"
+  | "Completed"
+  | "CompletedWithErrors"
+  | "Cancelled";
+
+/**
+ * A file picked up from the user's folder, before it has been uploaded or queued.
+ * Everything here lives only in the browser until the batch is submitted.
+ */
+export interface StagedDocument {
+  /** Stable per-session id; the File object itself can't be used as a React key. */
+  id: string;
+  file: File;
+  /** Path within the chosen folder, e.g. "contracts/2024/lease.pdf". */
+  relativePath: string;
+  /** Resolved lazily — PDFs are read in the browser, everything else asks the server. */
+  pageCount: number | null;
+  settings: DocumentSettings;
+  upload: UploadState;
+}
+
+/** The per-document choices the user can edit, individually or via select-all. */
+export interface DocumentSettings {
+  targetLanguageId: number;
+  /** 0 means "let the model detect it", matching the single-document flow. */
+  sourceLanguageId: number;
+  outputFormat: number;
+  model: number;
+  /** Free-text notes and translator instructions. */
+  instructions: string;
+  /** Confirmed proper-name spellings applied to this document. */
+  nameTranslations: NameTranslationItem[];
+}
+
+export interface UploadState {
+  status: "idle" | "uploading" | "uploaded" | "error";
+  /** 0..1, reported by the direct-to-Google upload. */
+  progress: number;
+  fileUri?: string;
+  mimeType?: string;
+  error?: string;
+}
+
+export interface CreateBatchItemRequest {
+  fileName: string;
+  relativePath: string;
+  fileUri: string;
+  mimeType: string;
+  pageCount: number;
+  targetLanguageId: number;
+  outputLanguageId: number;
+  sourceLanguageId: number | null;
+  outputFormat: number;
+  model: number;
+  instructions: string | null;
+  nameTranslations: NameTranslationItem[];
+}
+
+export interface CreateBatchRequest {
+  projectId: string;
+  name: string | null;
+  items: CreateBatchItemRequest[];
+}
+
+export interface BatchItem {
+  id: string;
+  sortOrder: number;
+  fileName: string;
+  relativePath: string | null;
+  status: BatchItemStatus;
+  attemptCount: number;
+  errorMessage: string | null;
+  jobId: string | null;
+  chatId: string | null;
+  targetLanguageId: number;
+  sourceLanguageId: number | null;
+  pageCount: number;
+  startedAt: string | null;
+  completedAt: string | null;
+  nextAttemptAt: string | null;
+}
+
+export interface Batch {
+  id: string;
+  projectId: string;
+  name: string | null;
+  status: BatchStatus;
+  totalItems: number;
+  pendingCount: number;
+  runningCount: number;
+  completedCount: number;
+  failedCount: number;
+  cancelledCount: number;
+  progressPercent: number;
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+  items: BatchItem[];
+}
+
+export interface BatchResponse {
+  success: boolean;
+  data: Batch;
+}
+
+export interface BatchListResponse {
+  success: boolean;
+  data: Batch[];
+}

--- a/src/features/bulkTranslation/utils/downloadAll.ts
+++ b/src/features/bulkTranslation/utils/downloadAll.ts
@@ -1,0 +1,226 @@
+import { getChatById } from "@/features/chatHistory";
+import { BatchItem } from "../types/types.Bulk";
+
+export type BulkDownloadFormat = "md" | "txt" | "docx" | "pdf";
+
+export interface BulkDownloadProgress {
+  completed: number;
+  total: number;
+  currentFile: string;
+}
+
+export interface BulkDownloadResult {
+  /** Documents written into the zip. */
+  succeeded: number;
+  /** Documents that could not be fetched or converted, with the reason. */
+  failed: Array<{ fileName: string; reason: string }>;
+}
+
+/**
+ * PDF generation renders each document through html2canvas, which is far slower than the
+ * other formats and holds a full canvas in memory while it works. Past this many documents
+ * the UI warns before starting rather than appearing to freeze.
+ */
+export const PDF_SLOW_THRESHOLD = 15;
+
+const markdownToHtml = async (content: string): Promise<string> => {
+  // Translations come back as either HTML or Markdown depending on the chosen output
+  // format, and the HTML ones must not be run through the Markdown parser again.
+  if (content.trimStart().startsWith("<")) return content;
+
+  const { marked } = await import("marked");
+  return marked(content, { async: false });
+};
+
+/** Word-compatible wrapper, matching the single-document DOCX export. */
+const buildDocxHtml = (bodyHtml: string): string => `<!DOCTYPE html>
+<html xmlns:o="urn:schemas-microsoft-com:office:office"
+      xmlns:w="urn:schemas-microsoft-com:office:word"
+      xmlns="http://www.w3.org/TR/REC-html40">
+<head>
+  <meta charset="utf-8">
+  <style>
+    body  { font-family: Calibri, sans-serif; font-size: 11pt; }
+    h1    { font-size: 16pt; }
+    h2    { font-size: 14pt; }
+    h3    { font-size: 12pt; }
+    p     { margin: 0 0 8pt 0; }
+    table { border-collapse: collapse; width: 100%; }
+    td, th { border: 1pt solid #aaa; padding: 4pt 8pt; }
+  </style>
+</head>
+<body>${bodyHtml}</body>
+</html>`;
+
+const convertContent = async (
+  content: string,
+  format: BulkDownloadFormat,
+  fileName: string
+): Promise<Blob | string> => {
+  switch (format) {
+    case "md":
+      return content;
+
+    case "txt":
+      // Strip tags so an HTML-format translation still downloads as readable plain text.
+      return content.replace(/<[^>]+>/g, "");
+
+    case "docx": {
+      const html = await markdownToHtml(content);
+      // @ts-expect-error html-docx-js ships no types
+      const htmlDocx = (await import("html-docx-js/dist/html-docx")).default;
+      return htmlDocx.asBlob(buildDocxHtml(html)) as Blob;
+    }
+
+    case "pdf": {
+      const html = await markdownToHtml(content);
+      const { generatePdfBlobFromHtml } = await import(
+        "@/features/translation/utils/html2pdf-client"
+      );
+      return generatePdfBlobFromHtml(html, fileName);
+    }
+  }
+};
+
+/**
+ * Rewrites a source path to the translated output path, preserving folder structure.
+ * "contracts/2024/lease.pdf" with suffix "translated" becomes
+ * "contracts/2024/lease_translated.docx".
+ */
+export const buildOutputPath = (
+  relativePath: string,
+  fileName: string,
+  format: BulkDownloadFormat,
+  translatedSuffix: string
+): string => {
+  const source = relativePath || fileName;
+  const lastSlash = source.lastIndexOf("/");
+  const folder = lastSlash === -1 ? "" : source.slice(0, lastSlash + 1);
+  const base = source.slice(lastSlash + 1).replace(/\.[^/.]+$/, "");
+
+  return `${folder}${base}_${translatedSuffix}.${format}`;
+};
+
+/**
+ * Zip entries must be unique. Two source files that differ only by extension
+ * (report.doc and report.pdf) collapse onto the same output name, and JSZip would
+ * silently keep only the last one — losing a translation the user paid for.
+ */
+const makeUnique = (path: string, taken: Set<string>): string => {
+  if (!taken.has(path)) {
+    taken.add(path);
+    return path;
+  }
+
+  const dot = path.lastIndexOf(".");
+  const base = dot === -1 ? path : path.slice(0, dot);
+  const ext = dot === -1 ? "" : path.slice(dot);
+
+  let counter = 2;
+  let candidate = `${base} (${counter})${ext}`;
+  while (taken.has(candidate)) {
+    counter += 1;
+    candidate = `${base} (${counter})${ext}`;
+  }
+
+  taken.add(candidate);
+  return candidate;
+};
+
+/**
+ * Fetches every completed translation in a batch, converts it to the chosen format, and
+ * saves them as one zip that mirrors the uploaded folder structure.
+ */
+export const downloadBatchAsZip = async (
+  items: BatchItem[],
+  format: BulkDownloadFormat,
+  zipName: string,
+  translatedSuffix: string,
+  onProgress?: (progress: BulkDownloadProgress) => void
+): Promise<BulkDownloadResult> => {
+  const completed = items.filter(
+    (item) => item.status === "Completed" && item.chatId
+  );
+
+  if (completed.length === 0) {
+    return { succeeded: 0, failed: [] };
+  }
+
+  const JSZip = (await import("jszip")).default;
+  const zip = new JSZip();
+  const takenPaths = new Set<string>();
+  const failed: BulkDownloadResult["failed"] = [];
+  let succeeded = 0;
+
+  // Sequential rather than parallel: PDF conversion is CPU-bound and renders through the
+  // DOM, so running several at once makes the whole tab unresponsive without finishing
+  // any sooner.
+  for (const [index, item] of completed.entries()) {
+    onProgress?.({
+      completed: index,
+      total: completed.length,
+      currentFile: item.fileName,
+    });
+
+    try {
+      const chat = await getChatById(item.chatId!);
+      const content = chat.data?.translationResult?.translatedContent;
+
+      if (!content) {
+        failed.push({
+          fileName: item.fileName,
+          reason: "No translated content was returned",
+        });
+        continue;
+      }
+
+      const outputPath = makeUnique(
+        buildOutputPath(
+          item.relativePath || item.fileName,
+          item.fileName,
+          format,
+          translatedSuffix
+        ),
+        takenPaths
+      );
+
+      const converted = await convertContent(content, format, outputPath);
+      zip.file(outputPath, converted);
+      succeeded += 1;
+    } catch (error) {
+      failed.push({
+        fileName: item.fileName,
+        reason: error instanceof Error ? error.message : "Conversion failed",
+      });
+    }
+  }
+
+  onProgress?.({
+    completed: completed.length,
+    total: completed.length,
+    currentFile: "",
+  });
+
+  if (succeeded === 0) {
+    return { succeeded, failed };
+  }
+
+  // A manifest of what didn't make it, so a partial download is self-explaining rather
+  // than leaving the user to work out which documents are missing.
+  if (failed.length > 0) {
+    zip.file(
+      "_missing-documents.txt",
+      [
+        "These documents could not be included in this download:",
+        "",
+        ...failed.map((f) => `- ${f.fileName}: ${f.reason}`),
+      ].join("\n")
+    );
+  }
+
+  const blob = await zip.generateAsync({ type: "blob" });
+  const { saveAs } = await import("file-saver");
+  saveAs(blob, `${zipName}.zip`);
+
+  return { succeeded, failed };
+};

--- a/src/features/bulkTranslation/utils/folderScanning.ts
+++ b/src/features/bulkTranslation/utils/folderScanning.ts
@@ -1,0 +1,246 @@
+/**
+ * Turning a dropped or picked folder into a flat list of translatable documents.
+ *
+ * Two entry points exist because the browser exposes folders two different ways: a file input
+ * with `webkitdirectory` yields a flat FileList carrying `webkitRelativePath`, while a drag-drop
+ * yields a tree that has to be walked.
+ */
+
+/** Extensions the document pipeline can translate through the Gemini Files API path. */
+const SUPPORTED_EXTENSIONS = [
+  ".pdf",
+  ".docx",
+  ".doc",
+  ".txt",
+  ".md",
+  ".markdown",
+  ".jpg",
+  ".jpeg",
+  ".png",
+] as const;
+
+/**
+ * Subtitles are deliberately excluded. They have their own backend path that preserves
+ * sequence numbers and timestamps; running them through the generic document translator
+ * would return prose and silently destroy the timing structure.
+ */
+const EXCLUDED_EXTENSIONS = [".srt"] as const;
+
+/** Matches the per-file cap the single-document upload form enforces. */
+export const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024;
+
+const MIME_TYPES: Record<string, string> = {
+  ".pdf": "application/pdf",
+  ".docx":
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ".doc": "application/msword",
+  ".txt": "text/plain",
+  ".md": "text/plain",
+  ".markdown": "text/plain",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+};
+
+export interface ScannedFile {
+  file: File;
+  relativePath: string;
+}
+
+export interface FolderScanResult {
+  accepted: ScannedFile[];
+  /** Files left out, with a reason to show the user rather than dropping them silently. */
+  rejected: Array<{ name: string; relativePath: string; reason: RejectionReason }>;
+}
+
+export type RejectionReason = "unsupported" | "subtitles" | "too-large" | "empty";
+
+export const getExtension = (fileName: string): string => {
+  const dot = fileName.lastIndexOf(".");
+  return dot === -1 ? "" : fileName.slice(dot).toLowerCase();
+};
+
+export const isSupportedFile = (fileName: string): boolean =>
+  (SUPPORTED_EXTENSIONS as readonly string[]).includes(getExtension(fileName));
+
+/**
+ * Browsers leave `File.type` empty for some sources (notably drag-drop on Linux and any
+ * extension the OS doesn't recognise), and Gemini rejects an upload with no MIME type, so
+ * fall back to mapping from the extension.
+ */
+export const resolveMimeType = (file: File): string =>
+  file.type || MIME_TYPES[getExtension(file.name)] || "application/octet-stream";
+
+/**
+ * Files the OS or archive tools scatter through folders that are never user content.
+ * Without this a single dropped folder can arrive with dozens of junk entries.
+ */
+const isJunkPath = (relativePath: string): boolean => {
+  const segments = relativePath.split("/");
+  return segments.some(
+    (segment) =>
+      segment.startsWith(".") ||
+      segment === "__MACOSX" ||
+      segment === "Thumbs.db" ||
+      segment === "desktop.ini"
+  );
+};
+
+const classify = (file: File, relativePath: string): RejectionReason | null => {
+  if (isJunkPath(relativePath)) return "unsupported";
+  if ((EXCLUDED_EXTENSIONS as readonly string[]).includes(getExtension(file.name)))
+    return "subtitles";
+  if (!isSupportedFile(file.name)) return "unsupported";
+  if (file.size === 0) return "empty";
+  if (file.size > MAX_FILE_SIZE_BYTES) return "too-large";
+  return null;
+};
+
+const partition = (scanned: ScannedFile[]): FolderScanResult => {
+  const accepted: ScannedFile[] = [];
+  const rejected: FolderScanResult["rejected"] = [];
+
+  for (const entry of scanned) {
+    const reason = classify(entry.file, entry.relativePath);
+    if (reason) {
+      // Junk files are noise, not something the user chose to include, so they are
+      // dropped entirely rather than reported.
+      if (!isJunkPath(entry.relativePath)) {
+        rejected.push({
+          name: entry.file.name,
+          relativePath: entry.relativePath,
+          reason,
+        });
+      }
+      continue;
+    }
+    accepted.push(entry);
+  }
+
+  // Folder order from the filesystem is arbitrary; sorting by path keeps the list stable
+  // and groups each subfolder's documents together.
+  accepted.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+
+  return { accepted, rejected };
+};
+
+/** Handles the `<input type="file" webkitdirectory>` case. */
+export const scanFileList = (fileList: FileList): FolderScanResult => {
+  const scanned: ScannedFile[] = Array.from(fileList).map((file) => ({
+    file,
+    // webkitRelativePath is empty when individual files were picked rather than a folder.
+    relativePath:
+      (file as File & { webkitRelativePath?: string }).webkitRelativePath ||
+      file.name,
+  }));
+
+  return partition(scanned);
+};
+
+interface FileSystemEntryLike {
+  isFile: boolean;
+  isDirectory: boolean;
+  name: string;
+  fullPath: string;
+  file?: (cb: (file: File) => void, err: (e: unknown) => void) => void;
+  createReader?: () => {
+    readEntries: (
+      cb: (entries: FileSystemEntryLike[]) => void,
+      err: (e: unknown) => void
+    ) => void;
+  };
+}
+
+const readEntryFile = (entry: FileSystemEntryLike): Promise<File | null> =>
+  new Promise((resolve) => {
+    entry.file?.(
+      (file) => resolve(file),
+      () => resolve(null)
+    );
+  });
+
+/**
+ * Reads one directory completely.
+ *
+ * `readEntries` returns at most 100 entries per call and signals the end with an empty
+ * batch, so a single call silently truncates any folder with more than 100 items — which is
+ * exactly the size of folder this feature exists to handle.
+ */
+const readAllEntries = async (
+  entry: FileSystemEntryLike
+): Promise<FileSystemEntryLike[]> => {
+  const reader = entry.createReader?.();
+  if (!reader) return [];
+
+  const all: FileSystemEntryLike[] = [];
+
+  for (;;) {
+    const batch = await new Promise<FileSystemEntryLike[]>((resolve) => {
+      reader.readEntries(
+        (entries) => resolve(entries),
+        () => resolve([])
+      );
+    });
+
+    if (batch.length === 0) break;
+    all.push(...batch);
+  }
+
+  return all;
+};
+
+const walkEntry = async (
+  entry: FileSystemEntryLike,
+  parentPath: string,
+  collected: ScannedFile[]
+): Promise<void> => {
+  const path = parentPath ? `${parentPath}/${entry.name}` : entry.name;
+
+  if (entry.isFile) {
+    const file = await readEntryFile(entry);
+    if (file) collected.push({ file, relativePath: path });
+    return;
+  }
+
+  if (entry.isDirectory) {
+    const children = await readAllEntries(entry);
+    // Sequential rather than parallel: a deep folder tree can otherwise open hundreds of
+    // concurrent directory readers, which browsers throttle unpredictably.
+    for (const child of children) {
+      await walkEntry(child, path, collected);
+    }
+  }
+};
+
+/** Handles a dropped folder, walking the directory tree the browser exposes. */
+export const scanDataTransfer = async (
+  dataTransfer: DataTransfer
+): Promise<FolderScanResult> => {
+  // DataTransferItemList is emptied as soon as the event handler yields, so every entry
+  // must be taken synchronously, before the first await.
+  const entries: FileSystemEntryLike[] = [];
+  for (const item of Array.from(dataTransfer.items)) {
+    const entry = (
+      item as DataTransferItem & {
+        webkitGetAsEntry?: () => FileSystemEntryLike | null;
+      }
+    ).webkitGetAsEntry?.();
+    if (entry) entries.push(entry);
+  }
+
+  // Browsers without the entry API still deliver a flat file list.
+  if (entries.length === 0) return scanFileList(dataTransfer.files);
+
+  const collected: ScannedFile[] = [];
+  for (const entry of entries) {
+    await walkEntry(entry, "", collected);
+  }
+
+  return partition(collected);
+};
+
+export const formatFileSize = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};

--- a/src/features/bulkTranslation/utils/pageCounting.ts
+++ b/src/features/bulkTranslation/utils/pageCounting.ts
@@ -1,0 +1,44 @@
+import { countPages } from "@/features/translation/services/countPagesService";
+import { getExtension } from "./folderScanning";
+
+/**
+ * Page count drives both the price and the time estimate, so it has to be right — sending 1
+ * for a 40-page document would undercharge the user and badly misreport progress.
+ *
+ * PDFs are counted in the browser. The server endpoint would also work, but it takes the
+ * whole file as an upload: for a folder of fifty 8MB scans that is another 400MB pushed
+ * over the wire purely to learn a number the browser can read from the file's own index.
+ */
+export const countPagesForFile = async (file: File): Promise<number> => {
+  if (getExtension(file.name) === ".pdf") {
+    const clientCount = await countPdfPagesInBrowser(file);
+    if (clientCount !== null) return clientCount;
+  }
+
+  // Everything else (and any PDF we couldn't parse) falls back to the server, which is the
+  // same path the single-document flow uses.
+  try {
+    const result = await countPages(file);
+    return Math.max(1, result?.pageCount ?? 1);
+  } catch {
+    // A failed count must not block the batch; the backend clamps to at least one page.
+    return 1;
+  }
+};
+
+/**
+ * Returns null when the PDF cannot be parsed locally — encrypted files being the common
+ * case — so the caller can fall back to the server rather than reporting a wrong count.
+ */
+const countPdfPagesInBrowser = async (file: File): Promise<number | null> => {
+  try {
+    const { PDFDocument } = await import("pdf-lib");
+    const bytes = await file.arrayBuffer();
+    // Encrypted PDFs throw unless this is set; we only read the page count, never content.
+    const pdf = await PDFDocument.load(bytes, { ignoreEncryption: true });
+    const count = pdf.getPageCount();
+    return count > 0 ? count : null;
+  } catch {
+    return null;
+  }
+};

--- a/src/features/bulkTranslation/utils/uploadPool.ts
+++ b/src/features/bulkTranslation/utils/uploadPool.ts
@@ -1,0 +1,44 @@
+/**
+ * Runs async tasks with a bounded number in flight.
+ *
+ * Uploading a folder is the one place this app can accidentally start fifty concurrent
+ * multi-megabyte requests. Browsers cap connections per host anyway, so the extra requests
+ * would just queue invisibly — but each one holds its File in memory and its own progress
+ * state, and the queued ones report no progress at all, which reads as a hang.
+ */
+export const runWithConcurrency = async <T, R>(
+  items: T[],
+  limit: number,
+  task: (item: T, index: number) => Promise<R>
+): Promise<R[]> => {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+
+  const worker = async () => {
+    for (;;) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      results[index] = await task(items[index], index);
+    }
+  };
+
+  const workers = Array.from(
+    { length: Math.max(1, Math.min(limit, items.length)) },
+    worker
+  );
+
+  await Promise.all(workers);
+  return results;
+};
+
+/**
+ * How many files upload at once.
+ *
+ * Chrome allows six connections per host and the upload goes straight to Google, so beyond
+ * six the extra transfers stall behind the others while still looking active. Four leaves
+ * headroom for the page-count and status-polling requests happening alongside.
+ */
+export const UPLOAD_CONCURRENCY = 4;
+
+/** Page counting is cheap for PDFs but hits the API for other formats; keep it modest. */
+export const PAGE_COUNT_CONCURRENCY = 4;

--- a/src/features/translation/services/geminiUploadService.ts
+++ b/src/features/translation/services/geminiUploadService.ts
@@ -1,22 +1,204 @@
 import { GeminiUploadResponse } from "@/features/translation/types/types.Translation";
+import { reaccessToken, useAuthStore } from "@/features/auth";
 
-export async function uploadFileToGemini(
-  file: File
-): Promise<GeminiUploadResponse> {
+export interface GeminiUploadOptions {
+  /** Fraction of bytes sent, 0..1. Only fires while the file is going to Google. */
+  onProgress?: (fraction: number) => void;
+  signal?: AbortSignal;
+}
+
+/** Vercel rejects serverless request bodies above this, so the proxy can't carry more. */
+const PROXY_FALLBACK_LIMIT_BYTES = 4 * 1024 * 1024;
+
+/** Raised when the browser could not reach Google at all, as opposed to being refused. */
+class DirectUploadUnreachableError extends Error {}
+
+/**
+ * Opens a resumable upload session on our own API. The response is just a session URL —
+ * the bytes never pass through Vercel, which is what keeps files over ~4.5MB working.
+ */
+async function openUploadSession(file: File): Promise<string> {
+  const payload = JSON.stringify({
+    fileName: file.name,
+    mimeType: file.type || "application/octet-stream",
+    sizeBytes: file.size,
+  });
+
+  const { token, refreshToken } = useAuthStore.getState();
+  if (!token) {
+    throw new Error("No token found");
+  }
+
+  const send = (bearer: string) =>
+    fetch("/api/gemini-upload", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${bearer}`,
+      },
+      body: payload,
+    });
+
+  let response = await send(token);
+
+  if (response.status === 401 && refreshToken) {
+    try {
+      const newTokens = (await reaccessToken(refreshToken)) as {
+        token: string;
+        refreshToken: string;
+      };
+      const { setToken, setRefreshToken } = useAuthStore.getState();
+      setToken(newTokens.token);
+      setRefreshToken(newTokens.refreshToken);
+      response = await send(newTokens.token);
+    } catch {
+      useAuthStore.getState().reset();
+      throw new Error("Token refresh failed");
+    }
+  }
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(
+      errorData.error || `Could not start upload (status ${response.status})`
+    );
+  }
+
+  const { uploadUrl } = (await response.json()) as { uploadUrl?: string };
+  if (!uploadUrl) {
+    throw new Error("No upload URL returned");
+  }
+
+  return uploadUrl;
+}
+
+/**
+ * Sends the file straight to Google. Uses XHR rather than fetch because only XHR reports
+ * upload progress, which matters when a batch is pushing many multi-megabyte files.
+ */
+function sendBytesToGoogle(
+  uploadUrl: string,
+  file: File,
+  options?: GeminiUploadOptions
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("POST", uploadUrl, true);
+    xhr.setRequestHeader("X-Goog-Upload-Offset", "0");
+    xhr.setRequestHeader("X-Goog-Upload-Command", "upload, finalize");
+    xhr.setRequestHeader(
+      "Content-Type",
+      file.type || "application/octet-stream"
+    );
+
+    const onAbort = () => xhr.abort();
+    options?.signal?.addEventListener("abort", onAbort);
+
+    const cleanup = () => options?.signal?.removeEventListener("abort", onAbort);
+
+    if (options?.onProgress) {
+      xhr.upload.onprogress = (event) => {
+        if (event.lengthComputable && event.total > 0) {
+          options.onProgress?.(event.loaded / event.total);
+        }
+      };
+    }
+
+    xhr.onload = () => {
+      cleanup();
+
+      if (xhr.status < 200 || xhr.status >= 300) {
+        reject(
+          new Error(
+            `Gemini rejected the upload (status ${xhr.status}): ${xhr.responseText.slice(0, 200)}`
+          )
+        );
+        return;
+      }
+
+      try {
+        const fileUri = JSON.parse(xhr.responseText)?.file?.uri;
+        if (!fileUri) {
+          reject(new Error("Gemini did not return a file URI"));
+          return;
+        }
+        resolve(fileUri);
+      } catch {
+        reject(new Error("Could not parse Gemini's upload response"));
+      }
+    };
+
+    xhr.onerror = () => {
+      cleanup();
+      // No status here means the request never completed — almost always a dropped
+      // connection, or a CORS rejection on the direct-to-Google request. Distinguished
+      // from a real rejection so the caller knows the proxy is worth trying.
+      reject(new DirectUploadUnreachableError("Could not reach Gemini"));
+    };
+
+    xhr.onabort = () => {
+      cleanup();
+      reject(new DOMException("Upload aborted", "AbortError"));
+    };
+
+    xhr.send(file);
+  });
+}
+
+/**
+ * Last-resort path that pushes the bytes through our own API instead of straight to
+ * Google. Kept only for the case where the browser cannot make the cross-origin request.
+ */
+async function uploadViaProxy(file: File): Promise<GeminiUploadResponse> {
   const formData = new FormData();
   formData.append("file", file);
 
+  const { token } = useAuthStore.getState();
   const response = await fetch("/api/gemini-upload", {
     method: "POST",
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
     body: formData,
   });
 
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({}));
     throw new Error(
-      errorData.error || `Gemini upload failed with status ${response.status}`
+      errorData.error || `Upload failed with status ${response.status}`
     );
   }
 
   return response.json() as Promise<GeminiUploadResponse>;
+}
+
+export async function uploadFileToGemini(
+  file: File,
+  options?: GeminiUploadOptions
+): Promise<GeminiUploadResponse> {
+  const uploadUrl = await openUploadSession(file);
+
+  try {
+    const fileUri = await sendBytesToGoogle(uploadUrl, file, options);
+    return {
+      fileUri,
+      mimeType: file.type || "application/octet-stream",
+      displayName: file.name,
+    };
+  } catch (error) {
+    const unreachable = error instanceof DirectUploadUnreachableError;
+    const fitsThroughProxy = file.size <= PROXY_FALLBACK_LIMIT_BYTES;
+
+    if (!unreachable || !fitsThroughProxy) {
+      if (unreachable) {
+        throw new Error(
+          `Could not reach Gemini to upload "${file.name}", and at ${(file.size / 1024 / 1024).toFixed(1)}MB it is too large to send through the server instead.`
+        );
+      }
+      throw error;
+    }
+
+    console.warn(
+      "[gemini-upload] Direct upload unreachable, falling back to server proxy"
+    );
+    return uploadViaProxy(file);
+  }
 }

--- a/src/features/translation/types/marked.d.ts
+++ b/src/features/translation/types/marked.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Minimal typing for `marked`.
+ *
+ * The installed build resolves to an ESM file with no bundled declarations, so every call
+ * site otherwise trips TS7016. Existing callers work around this with `require()` casts;
+ * this declaration lets them use a normal dynamic import instead.
+ *
+ * Only the synchronous form is declared, which is the only way this codebase calls it —
+ * `marked` returns a Promise unless `async: false` is passed.
+ */
+declare module "marked" {
+  export function marked(src: string, options?: { async?: false }): string;
+}

--- a/src/features/translation/utils/html2pdf-client.ts
+++ b/src/features/translation/utils/html2pdf-client.ts
@@ -4,19 +4,23 @@ type Html2PdfInstance = {
   set: (options: unknown) => Html2PdfInstance;
   from: (input: string) => Html2PdfInstance;
   save: () => Promise<void>;
+  outputPdf: (type: "blob") => Promise<Blob>;
 };
 
 type Html2PdfFactory = () => Html2PdfInstance;
 
-export const generatePdfFromHtml = async (
-  htmlContent: string,
-  filename: string = "translated_document.pdf"
-): Promise<void> => {
+const loadHtml2Pdf = async (): Promise<Html2PdfFactory> => {
   const html2pdfModule = await import("html2pdf.js");
+  return (html2pdfModule.default || html2pdfModule) as Html2PdfFactory;
+};
 
-  const html2pdf: Html2PdfFactory =
-    (html2pdfModule.default || html2pdfModule) as Html2PdfFactory;
-
+/**
+ * Styling and layout for generated PDFs.
+ *
+ * Shared by the single-file download and the bulk zip so a document exported on its own and
+ * the same document exported inside a batch come out identical.
+ */
+const buildPdfDocument = (htmlContent: string, filename: string) => {
   const styles = `
     <style>
       * { box-sizing: border-box; color: #111 !important; }
@@ -72,11 +76,37 @@ export const generatePdfFromHtml = async (
     },
   };
 
+  return { options, source: styles + htmlContent };
+};
+
+export const generatePdfFromHtml = async (
+  htmlContent: string,
+  filename: string = "translated_document.pdf"
+): Promise<void> => {
+  const html2pdf = await loadHtml2Pdf();
+  const { options, source } = buildPdfDocument(htmlContent, filename);
+
   try {
-    await html2pdf()
-      .set(options)
-      .from(styles + htmlContent)
-      .save();
+    await html2pdf().set(options).from(source).save();
+  } catch (error) {
+    console.error("PDF generation failed:", error);
+    throw new Error("Failed to generate PDF");
+  }
+};
+
+/**
+ * Same output as {@link generatePdfFromHtml}, returned as a Blob instead of being saved.
+ * Needed for the bulk download, where the PDFs go into a zip rather than to disk one by one.
+ */
+export const generatePdfBlobFromHtml = async (
+  htmlContent: string,
+  filename: string = "translated_document.pdf"
+): Promise<Blob> => {
+  const html2pdf = await loadHtml2Pdf();
+  const { options, source } = buildPdfDocument(htmlContent, filename);
+
+  try {
+    return await html2pdf().set(options).from(source).outputPdf("blob");
   } catch (error) {
     console.error("PDF generation failed:", error);
     throw new Error("Failed to generate PDF");


### PR DESCRIPTION
Frontend for bulk folder translation. Pairs with [Api24.ContentAI#76](https://github.com/goga0301/Api24.ContentAI/pull/76), already merged and deployed.

**This PR contains two independent changes.** They are together because the bulk feature depends on the upload one, but they can be reviewed separately — and the upload fix affects every existing upload, not just bulk.

---

## 1. Direct-to-Google upload — fixes the 413s

The 413s on 7–8MB files were **never Gemini**, which accepts 2GB. `/api/gemini-upload` is a Vercel serverless function, and **Vercel rejects request bodies over ~4.5MB at the edge**, before the handler ever runs.

Two things hid this:
- `next.config.ts` sets `bodySizeLimit: "11mb"`, which applies **only to Server Actions**, not Route Handlers
- the client fell back to `` `Gemini upload failed with status ${response.status}` `` when the error body wasn't JSON — **relabelling Vercel's rejection as Gemini's**

The route now returns only a resumable session URL and the browser sends bytes straight to Google, so file size never touches Vercel's limit. XHR rather than fetch because only XHR reports upload progress.

**Why not compression, as originally suggested:** DOCX is already a ZIP, so it would gain nothing, and compressing a PDF means downsampling images — which destroys OCR quality on exactly the scanned documents being translated.

**Security:** the route required no authentication, so anyone could spend the account's Gemini quota. It now requires a bearer token and validates it against `/Subscription/me`. A proxy fallback is kept for files under 4MB, so the worst case is today's behaviour rather than a total failure.

## 2. Bulk folder translation

New route `/projects/[id]/bulk`: drop a folder → review what was found → set language pairs and notes per document *or across a selection* → queue → download everything as one zip mirroring the original folder structure.

Decisions worth checking:

| Decision | Reason |
|---|---|
| PDF page counts read in-browser via `pdf-lib` | The server endpoint takes the whole file — for fifty 8MB scans that's another 400MB uploaded to learn a number already in the file's index. Page count sets the price, so defaulting to 1 would undercharge. |
| Uploads run 4 at a time | Browsers allow 6 connections per host; beyond that transfers stall while still appearing active. |
| Directory reads loop until empty | `readEntries` returns **at most 100 entries per call** — a single call silently truncates any folder above 100 files, exactly the size this feature exists for. |
| Zip entry names deduplicated | `report.doc` and `report.pdf` both become `report_translated.docx`; JSZip would keep only the last, losing a paid-for translation. |
| Subtitles excluded | SRT has its own backend path that preserves timestamps; the generic path would return prose and destroy the timing. |
| Progress counts failed documents as settled | A bar stuck at 94% because two files failed reads as a hang. |

## ⚠️ Known gap

**Strings in the bulk UI are hardcoded English.** The rest of the app goes through `next-intl`. This needs extracting before it reaches Georgian and Polish users — only the `bulkTranslate` button label was localised. I'd suggest it as a follow-up rather than blocking this.

## Verification

- `tsc --noEmit` — clean
- `next lint` — clean (only pre-existing warnings, none in new files)
- `next build` — **compiles successfully**; the local build then fails collecting `/api/blog` because my `.env.local` has a placeholder Supabase key. That route is untouched here and Vercel has the real key.

**Not verified:** the end-to-end path — queue a batch, worker translates, download the zip — has not been run against the deployed backend. That's the first thing to do on the preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)