### PR TITLE
fix: bulk download failed with "p is not a function"

### DIFF
--- a/src/features/bulkTranslation/utils/downloadAll.ts
+++ b/src/features/bulkTranslation/utils/downloadAll.ts
@@ -1,3 +1,4 @@
+import { saveAs } from "file-saver";
 import { getChatById } from "@/features/chatHistory";
 import { BatchItem } from "../types/types.Bulk";
 
@@ -219,7 +220,13 @@ export const downloadBatchAsZip = async (
   }
 
   const blob = await zip.generateAsync({ type: "blob" });
-  const { saveAs } = await import("file-saver");
+
+  // Statically imported, unlike the other libraries here. file-saver is CommonJS, and
+  // `await import("file-saver")` puts the function on `.default` while leaving `.saveAs`
+  // undefined — so destructuring it dynamically silently yields undefined and the call
+  // fails at the very end, after every document has already been converted. The static
+  // form goes through webpack's named-export interop and is what the rest of the codebase
+  // uses.
   saveAs(blob, `${zipName}.zip`);
 
   return { succeeded, failed };


### PR DESCRIPTION
Every bulk download threw a `TypeError` at the final step — after all documents had already been fetched and converted, which is the most expensive possible place to fail.

## Cause

`file-saver` is CommonJS. `await import("file-saver")` returns a namespace where the function lives on `.default` and **`.saveAs` is `undefined`**, so destructuring `{ saveAs }` silently produced `undefined`. Minified, that binding became `p` — hence **"p is not a function"**, a message pointing nowhere near file-saver.

## Verified in a browser, not inferred

A throwaway diagnostic page exercising each dynamic import in a real bundle:

```
file-saver DYNAMIC (old, broken): .saveAs=undefined, .default=function
file-saver STATIC  (the fix):     saveAs=function
zip built: size=126; calling saveAs...
saveAs RETURNED WITHOUT THROWING
```

The static import goes through webpack's named-export interop, and is what the two existing callers (`DownloadButton.tsx`, `PassportPage.tsx`) already use.

## What this was *not*

PDF was the reported symptom, so PDF generation was the obvious suspect. The same self-test produced a **valid PDF blob — `application/pdf`, 8573 bytes**. `html2pdf.js`, `jszip`, `marked` and `html-docx-js` all resolved correctly.

The bug hit **every format equally** — the zip is saved by that one line regardless of what went into it. Worth knowing, because "the PDF export is broken" would have sent the next person to the wrong file.

## Verification

- `tsc --noEmit` — clean
- `next lint` — clean
- Round-tripped in a browser: build a zip → `saveAs` → returns without throwing

🤖 Generated with [Claude Code](https://claude.com/claude-code)